### PR TITLE
marozzin pull request

### DIFF
--- a/mysql/diag/sql/blocking-sessions.sql
+++ b/mysql/diag/sql/blocking-sessions.sql
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+*/
+
+SELECT
+    trx_id,
+    trx_state,
+    trx_wait_started,
+    trx_requested_lock_id,
+    time_to_sec(timediff(now(),trx_started)) AS cq,
+    lock_type,
+    lock_table,
+    lock_index,
+    lock_data 
+FROM
+    information_schema.innodb_trx LEFT JOIN information_schema.innodb_locks ON trx_requested_lock_id=lock_id
+;

--- a/mysql/diag/sql/innodb-table-tablespace.sql
+++ b/mysql/diag/sql/innodb-table-tablespace.sql
@@ -1,0 +1,15 @@
+/*
+Reference
+https://dev.mysql.com/doc/refman/5.6/en/innodb-multiple-tablespaces.html
+*/
+
+select
+    TABLE_ID,
+    NAME,
+    case SPACE
+        when 0 then 'system'
+        else 'file per table'
+    end as TABLESPACE
+from 
+    INNODB_SYS_TABLES
+;

--- a/mysql/diag/sql/kill-queries-builder.sql
+++ b/mysql/diag/sql/kill-queries-builder.sql
@@ -1,0 +1,52 @@
+/*
+ * Meta-query to build RDS kill query calls for queries that associated to selected threads.
+ * The mysql.rds_kill_query(id) call terminates kill the query that is running on the thread id.
+ * Reference: 
+ * http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.CommonDBATasks.html#Appendix.MySQL.CommonDBATasks.Kill
+*/
+
+/*==============================================================================*/
+/* Set variables */
+/* 
+ * Use the following variables to select query threads to kill.
+ * All variables used to define the selection of thread to kill are in AND in the query statment.
+*/
+SET @QUERY_USER="%";    /*Filter for user, "%" for all users*/
+SET @QUERY_HOST="%";    /*Filter for host, "%" for all hosts*/
+SET @QUERY_DB="%";      /*Filter for DB, "%" for all DBs*/
+SET @QUERY_COMMAND="Query"; /*Filter ids for command thread is executing, "%" for all commands*/
+SET @QUERY_TIME_MIN=0;  /*Set minimum execution time for running thread ids, set 0 for all queries*/ 
+SET @QUERY_STATE="%";   /*Filter ids for query state, "%" for all states*/
+/*==============================================================================*/
+
+/*==============================================================================*/
+/* Define statment */
+SET @query=CONCAT(\
+    "SELECT  "\
+    "CONCAT(\"CALL mysql.rds_kill_query(\",id,\");\") AS KILL_QUERY_CMD, "\
+    "user, host, db, command, time, state, info "\
+    "from INFORMATION_SCHEMA.PROCESSLIST "\
+    "where user like \'" , @QUERY_USER, "\' "\
+    "and host like \'" , @QUERY_HOST, "\' "\
+    "and db like \'" , @QUERY_DB, "\' "\
+    "and command like \'" , @QUERY_COMMAND , "\' "\
+    "and time >= " , @QUERY_TIME_MIN , " "\
+    "and state like \'" , @QUERY_STATE , "\' "\
+);
+
+/* Prepare statment */
+PREPARE stmt FROM @query;
+
+/* Execute statment */
+EXECUTE stmt;
+
+/* Clean */
+DEALLOCATE PREPARE stmt;
+SET @query=Null;
+SET @QUERY_USER=Null;  
+SET @QUERY_HOST=Null;  
+SET @QUERY_DB=Null;  
+SET @QUERY_COMMAND=Null; 
+SET @QUERY_TIME_MIN=Null;
+SET @QUERY_STATE=Null;  
+/*==============================================================================*/

--- a/mysql/diag/sql/kill-sessions-builder.sql
+++ b/mysql/diag/sql/kill-sessions-builder.sql
@@ -1,0 +1,52 @@
+/*
+ * Meta-query to build RDS kill sessions calls for sessions that are running selected threads.
+ * The mysql.rds_kill(id) call terminates the connection associated with the given processlist_id, after terminating any statement the connection is executing.
+ * Reference: 
+ * http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.CommonDBATasks.html#Appendix.MySQL.CommonDBATasks.Kill
+*/
+
+/*==============================================================================*/
+/* Set variables */
+/* 
+ * Use the following variables to select threads to kill.
+ * All variables used to define the selection of thread to kill are in AND in the query statment.
+*/
+SET @QUERY_USER="%";    /*Filter for user, "%" for all users*/
+SET @QUERY_HOST="%";    /*Filter for host, "%" for all hosts*/
+SET @QUERY_DB="%";      /*Filter for DB, "%" for all DBs*/
+SET @QUERY_COMMAND="%"; /*Filter ids for command thread is executing, "%" for all commands*/
+SET @QUERY_TIME_MIN=0;  /*Set minimum execution time for running thread ids, set 0 for all queries*/ 
+SET @QUERY_STATE="%";   /*Filter ids for query state, "%" for all states*/
+/*==============================================================================*/
+
+/*==============================================================================*/
+/* Define statment */
+SET @query=CONCAT(\
+    "SELECT  "\
+    "CONCAT(\"CALL mysql.rds_kill(\",id,\");\") AS KILL_SESSION_CMD, "\
+    "user, host, db, command, time, state, info "\
+    "from INFORMATION_SCHEMA.PROCESSLIST "\
+    "where user like \'" , @QUERY_USER, "\' "\
+    "and host like \'" , @QUERY_HOST, "\' "\
+    "and db like \'" , @QUERY_DB, "\' "\
+    "and command like \'" , @QUERY_COMMAND , "\' "\
+    "and time >= " , @QUERY_TIME_MIN , " "\
+    "and state like \'" , @QUERY_STATE , "\' "\
+);
+
+/* Prepare statment */
+PREPARE stmt FROM @query;
+
+/* Execute statment */
+EXECUTE stmt;
+
+/* Clean */
+DEALLOCATE PREPARE stmt;
+SET @query=Null;
+SET @QUERY_USER=Null;  
+SET @QUERY_HOST=Null;  
+SET @QUERY_DB=Null;  
+SET @QUERY_COMMAND=Null; 
+SET @QUERY_TIME_MIN=Null;
+SET @QUERY_STATE=Null;  
+/*==============================================================================*/

--- a/mysql/diag/sql/space-allocation.sql
+++ b/mysql/diag/sql/space-allocation.sql
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/* Note. 
+ *      The query return an estimation of space allocated for enlisted structures only.
+ *      Structures as CSV tables, binary logs and log files are not accounted.
+ *      Query will show proper values only when statistics are up to date.
+ */
+select 
+    sum(data_length)/1024/1024 as data_lenght_mb,
+    sum(data_free)/1024/1024 as data_free_mb,
+    sum(index_length)/1024/1024 as index_lenght_mb,
+    (select (@@innodb_log_files_in_group * @@innodb_log_file_size)/1024/1024) as innodb_log_size_mb,
+    (sum(data_length)+sum(data_free)+sum(index_length)+(select (@@innodb_log_files_in_group * @@innodb_log_file_size)))/1024/1024 as tot_mb
+from 
+    information_schema.tables
+;

--- a/mysql/mysql.README
+++ b/mysql/mysql.README
@@ -26,7 +26,14 @@ script-name                          :   Description
 rds-support-tools/mysql/diag/sql
 #####################################
 
+blocking-sessions.sql               :   Show blocking sessions
+                    Tested on MySQL 5.6
 
+innodb-table-tablespace.sql         :   Show tablespace allocation for InnoDB engine tables. Show if table is allocated on system tablespace or per-file-tablespace 
+                    Tested on MySQL 5.6
+
+space-allocation.sql                :   Show sum of space allocation. Structures as CSV tables, binary logs and log files are not accounted. 
+                    Tested on MySQL 5.6
 
 #####################################
 rds-support-tools/mysql/diag/shell 

--- a/mysql/mysql.README
+++ b/mysql/mysql.README
@@ -35,6 +35,12 @@ innodb-table-tablespace.sql         :   Show tablespace allocation for InnoDB en
 space-allocation.sql                :   Show sum of space allocation. Structures as CSV tables, binary logs and log files are not accounted. 
                     Tested on MySQL 5.6
 
+kill-queries-builder.sql            :   Meta-query to build RDS Calls for mysql.rds_kill_query(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
+                    Tested on MySQL 5.6
+
+kill-sessions-builder.sql            :   Meta-query to build RDS Calls for mysql.rds_kill(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
+                    Tested on MySQL 5.6
+
 #####################################
 rds-support-tools/mysql/diag/shell 
 #####################################

--- a/oracle/diag/sql/oracle-12-patch-list-verbose.sql
+++ b/oracle/diag/sql/oracle-12-patch-list-verbose.sql
@@ -1,5 +1,19 @@
----The following query can be used in RDS Oracle 12c engine versions to list all patches installed with verbose output
-
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+*/
+          
 set long 200000 pages 0 lines 200
 select xmltransform(SYS.DBMS_QOPATCH.GET_OPATCH_LSINVENTORY, SYS.DBMS_QOPATCH.GET_OPATCH_XSLT) from dual;
 

--- a/oracle/diag/sql/oracle-12-patch-list-verbose.sql
+++ b/oracle/diag/sql/oracle-12-patch-list-verbose.sql
@@ -1,0 +1,5 @@
+---The following query can be used in RDS Oracle 12c engine versions to list all patches installed with verbose output
+
+set long 200000 pages 0 lines 200
+select xmltransform(DBMS_QOPATCH.GET_OPATCH_LSINVENTORY, DBMS_QOPATCH.GET_OPATCH_XSLT) from dual;
+

--- a/oracle/diag/sql/oracle-12-patch-list-verbose.sql
+++ b/oracle/diag/sql/oracle-12-patch-list-verbose.sql
@@ -1,5 +1,5 @@
 ---The following query can be used in RDS Oracle 12c engine versions to list all patches installed with verbose output
 
 set long 200000 pages 0 lines 200
-select xmltransform(DBMS_QOPATCH.GET_OPATCH_LSINVENTORY, DBMS_QOPATCH.GET_OPATCH_XSLT) from dual;
+select xmltransform(SYS.DBMS_QOPATCH.GET_OPATCH_LSINVENTORY, SYS.DBMS_QOPATCH.GET_OPATCH_XSLT) from dual;
 

--- a/oracle/diag/sql/oracle-12-patch-list.sql
+++ b/oracle/diag/sql/oracle-12-patch-list.sql
@@ -1,7 +1,7 @@
 ---The following query can be used in RDS Oracle 12c engine versions to list all patches installed
 set pages 1000 lines 20000
 
-with a as (select dbms_qopatch.get_opatch_lsinventory patch_output from dual)
+with a as (select SYS.dbms_qopatch.get_opatch_lsinventory patch_output from dual)
 select x.patch_id, x.patch_uid, x.description
 from a,
 xmltable('InventoryInstance/patches/*'

--- a/oracle/diag/sql/oracle-12-patch-list.sql
+++ b/oracle/diag/sql/oracle-12-patch-list.sql
@@ -1,0 +1,12 @@
+---The following query can be used in RDS Oracle 12c engine versions to list all patches installed
+set pages 1000 lines 20000
+
+with a as (select dbms_qopatch.get_opatch_lsinventory patch_output from dual)
+select x.patch_id, x.patch_uid, x.description
+from a,
+xmltable('InventoryInstance/patches/*'
+    passing a.patch_output
+    columns
+    patch_id number path 'patchID',
+    patch_uid number path 'uniquePatchID',
+    description varchar2(80) path 'patchDescription') x;

--- a/oracle/diag/sql/oracle-12-patch-list.sql
+++ b/oracle/diag/sql/oracle-12-patch-list.sql
@@ -1,4 +1,19 @@
----The following query can be used in RDS Oracle 12c engine versions to list all patches installed
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+*/
+
 set pages 1000 lines 20000
 
 with a as (select SYS.dbms_qopatch.get_opatch_lsinventory patch_output from dual)

--- a/oracle/oracle.README
+++ b/oracle/oracle.README
@@ -78,11 +78,11 @@ session-whr-sid.sql		    :   Outputs session detail for a prompted session id (s
 sql-text-whr-sql_id.sql	    	    :   Outputs sql text for a prompted sql_id
 					Tested on Oracle-SE2 12.1, Oracle-EE 12.1
 
-oracle-12-patch-list.sql            : Outputs list of Oracle patch installed - 12c versions only
-                    Tested on Oracle-SE 12.1, Oracle-EE 12.1
+oracle-12-patch-list.sql            : Outputs list of Oracle patch installed - 12c versions EE, SE and SE2  only
+                    Tested on Oracle-SE 12.1, Oracle-SE2 12.1, Oracle-EE 12.1
 
-oracle-12-patch-list-verbose.sql            : Outputs list and details of Oracle patch installed - 12c versions only
-                    Tested on Oracle-SE 12.1, Oracle-EE 12.1
+oracle-12-patch-list-verbose.sql            : Outputs list and details of Oracle patch installed - 12c versions EE, SE and SE2 only
+                    Tested on Oracle-SE 12.1, Oracle-SE2 12.1, Oracle-EE 12.1
 
 #####################################
 rds-support-tools/oracle/diag/shell

--- a/oracle/oracle.README
+++ b/oracle/oracle.README
@@ -78,6 +78,11 @@ session-whr-sid.sql		    :   Outputs session detail for a prompted session id (s
 sql-text-whr-sql_id.sql	    	    :   Outputs sql text for a prompted sql_id
 					Tested on Oracle-SE2 12.1, Oracle-EE 12.1
 
+oracle-12-patch-list.sql            : Outputs list of Oracle patch installed - 12c versions only
+                    Tested on Oracle-SE 12.1, Oracle-EE 12.1
+
+oracle-12-patch-list-verbose.sql            : Outputs list and details of Oracle patch installed - 12c versions only
+                    Tested on Oracle-SE 12.1, Oracle-EE 12.1
 
 #####################################
 rds-support-tools/oracle/diag/shell


### PR DESCRIPTION
Oracle

Review of Oracle patches installed on RDS Oracle instances equipped with 12c Oracle versions through the DBMS_QOPATCH.

These two SQL use the DBMS_QOPATCH to retrieve information regarding Oracle patch installed on RDS Oracle instances for 12c engine versions family. 

As managed database standard methods available for 11g too still require OS access and are not available for RDS instances.

A KC article written by mmssl@ was proposed regarding the usage of DBMS_QOPATCH for RDS Oracle 12c in order to allow customers to review patches installed. When the article it will published these scripts should be linked as available in the GitHub repository.

Commits:
 oracle/diag/sql/oracle-12-patch-list-verbose.sql 
 oracle/diag/sql/oracle-12-patch-list.sql 
 oracle/oracle.README

MySQL

Commits:
 mysql/diag/sql/

 mysql/diag/sql/blocking-sessions.sql

Blocking transactions

 mysql/diag/sql/innodb-table-tablespace.sql

To be aware regarding which InnoDB tables are allocated in the system tablespace and which in per-file-tablespace.

 mysql/diag/sql/kill-queries-builder.sql
 mysql/diag/sql/kill-sessions-builder.sql

Meta-queries to filter threads-id used to feed RDS Calls mysql.rds_kill(id) to kill sessions and mysql.rds_kill_query(id).
Refer to: http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.CommonDBATasks.html#Appendix.MySQL.CommonDBATasks.Kill

 mysql/diag/sql/space-allocation.sql

Retrieve information about space used by MySQL structure for which data are available on RDS.

 mysql/mysql.README
