### PR TITLE
Add MySQL SQL check-table-pk-missing.sql

### DIFF
--- a/mysql/diag/sql/check-table-pk-missing.sql
+++ b/mysql/diag/sql/check-table-pk-missing.sql
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/* Tables having PK not defined */
+SELECT '' AS 
+' 
+* Tables having PK not defined 
+**************************************************************
+'\G
+SELECT
+    t2.TABLE_SCHEMA,
+    t2.TABLE_NAME,
+    t2.ENGINE
+FROM    
+    information_schema.TABLES t2
+WHERE t2.TABLE_SCHEMA not in ('mysql','sys','INFORMATION_SCHEMA','PERFORMANCE_SCHEMA')
+AND CONCAT(t2.TABLE_SCHEMA,'.',t2.TABLE_NAME) not in 
+    (
+    SELECT 
+    CONCAT(t.TABLE_SCHEMA,'.',t.TABLE_NAME) 
+    FROM
+        information_schema.COLUMNS c,
+        information_schema.TABLES t
+    WHERE t.TABLE_SCHEMA not in ('mysql','sys')
+    AND c.TABLE_NAME=t.TABLE_NAME
+    AND c.TABLE_SCHEMA=t.TABLE_SCHEMA
+    AND c.COLUMN_KEY='PRI'
+    GROUP BY
+        t.TABLE_SCHEMA,
+        t.TABLE_NAME
+    )
+GROUP BY
+    t2.TABLE_SCHEMA,
+    t2.TABLE_NAME,
+    t2.ENGINE 
+;

--- a/mysql/mysql.README
+++ b/mysql/mysql.README
@@ -47,6 +47,9 @@ check-table-pk.sql                  :   Report tables having Primary Key defined
 check-table-pk-columns.sql          :   Report columns partecipating in Primary Key definition per schema per table
                     Tested on MySQL 5.6
 
+check-table-pk-missing.sql          :   Report tables having Primary Key not defined. 
+                    Tested on MySQL 5.6
+
 #####################################
 rds-support-tools/mysql/diag/shell 
 #####################################


### PR DESCRIPTION
Add MySQL SQL check-table-pk-missing.sql

Report table not having PK defined.
Useful to track down table that could have inefficient and hidden raw clustered index