### PR TITLE
Add MySQL SQL script check-idx-btree-not-unique-redundancy.sql

### DIFF
--- a/mysql/diag/sql/check-idx-btree-not-unique-redundancy.sql
+++ b/mysql/diag/sql/check-idx-btree-not-unique-redundancy.sql
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2016 Amazon.com, Inc. or its affiliates.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/* Tables having PK not defined */
+SELECT 
+' 
+**************************************************************
+* Find single column B-Tree NOT UNIQUE indexes that are 
+* defined as prefix of another composed index too.
+**************************************************************
+*
+* Note.
+*
+* 1. Sigle B-Tree and NOT UNIQUE indexes are compared wich each
+*    composed index per table.
+* 2. Cases where the prefix index is unique are not considered
+*    as the uniqueness of the prefix index in this case enforce
+*    a constraint not enforced by the longer index.
+**************************************************************
+' AS ''\G
+SELECT
+    CONCAT('The B-Tree NOT UNIQUE index ', IDX_PREFIX, ' is prefix of the composed index ', IDX_COMPOSED) AS Message,
+    CONCAT(TABLE_SCHEMA, '.', TABLE_NAME) AS FULL_TABLE_NAME,
+    IDX_PREFIX,
+    C_IDX_PREFIX,
+    IDX_COMPOSED,
+    C_IDX_COMPOSED
+FROM
+    (
+    SELECT
+        TABLE_SCHEMA,
+        TABLE_NAME,
+        INDEX_NAME AS 'IDX_PREFIX',
+        GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS C_IDX_PREFIX
+    FROM
+        information_schema.STATISTICS
+    WHERE TABLE_SCHEMA NOT IN ('mysql', 'sys', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA')
+    AND INDEX_TYPE='BTREE'
+    AND NON_UNIQUE=1
+    GROUP BY
+        TABLE_SCHEMA,
+        TABLE_NAME,
+        INDEX_NAME
+    ) AS idx1
+    INNER JOIN
+    (
+    SELECT
+        TABLE_SCHEMA,
+        TABLE_NAME,
+        INDEX_NAME AS 'IDX_COMPOSED',
+        GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS C_IDX_COMPOSED
+    FROM
+        information_schema.STATISTICS
+    WHERE INDEX_TYPE='BTREE' 
+    GROUP BY
+        TABLE_SCHEMA,
+        TABLE_NAME,
+        INDEX_NAME
+    ) AS idx2
+    USING (TABLE_SCHEMA, TABLE_NAME)
+    WHERE idx1.C_IDX_PREFIX != idx2.C_IDX_COMPOSED AND LOCATE(CONCAT(idx1.C_IDX_PREFIX, ','), idx2.C_IDX_COMPOSED) = 1
+;    

--- a/mysql/mysql.README
+++ b/mysql/mysql.README
@@ -26,28 +26,31 @@ script-name                          :   Description
 rds-support-tools/mysql/diag/sql
 #####################################
 
-blocking-sessions.sql               :   Show blocking sessions
+blocking-sessions.sql                   :   Show blocking sessions
                     Tested on MySQL 5.6
 
-innodb-table-tablespace.sql         :   Show tablespace allocation for InnoDB engine tables. Show if table is allocated on system tablespace or per-file-tablespace 
+innodb-table-tablespace.sql             :   Show tablespace allocation for InnoDB engine tables. Show if table is allocated on system tablespace or per-file-tablespace 
                     Tested on MySQL 5.6
 
-space-allocation.sql                :   Show sum of space allocation. Structures as CSV tables, binary logs and log files are not accounted. 
+space-allocation.sql                    :   Show sum of space allocation. Structures as CSV tables, binary logs and log files are not accounted. 
                     Tested on MySQL 5.6
 
-gen-kill-queries-command.sql        :   Meta-query to build RDS Calls for mysql.rds_kill_query(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
+gen-kill-queries-command.sql            :   Meta-query to build RDS Calls for mysql.rds_kill_query(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
                     Tested on MySQL 5.6
 
-gen-kill-sessions-command.sql       :   Meta-query to build RDS Calls for mysql.rds_kill(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
+gen-kill-sessions-command.sql           :   Meta-query to build RDS Calls for mysql.rds_kill(id) based of INFORMATION_SCHEMA.PROCESSLIST selection.
                     Tested on MySQL 5.6
 
-check-table-pk.sql                  :   Report tables having Primary Key defined per schema per table
+check-table-pk.sql                      :   Report tables having Primary Key defined per schema per table
                     Tested on MySQL 5.6
 
-check-table-pk-columns.sql          :   Report columns partecipating in Primary Key definition per schema per table
+check-table-pk-columns.sql              :   Report columns partecipating in Primary Key definition per schema per table
                     Tested on MySQL 5.6
 
-check-table-pk-missing.sql          :   Report tables having Primary Key not defined. 
+check-table-pk-missing.sql              :   Report tables having Primary Key not defined. 
+                    Tested on MySQL 5.6
+
+eck-idx-btree-not-unque-redundancy.sql  :   Find single column B-Tree NOT UNIQUE indexes that are defined as prefix of another composed index too.  
                     Tested on MySQL 5.6
 
 #####################################


### PR DESCRIPTION
Add MySQL SQL script check-idx-btree-not-unique-redundancy.sql

Find single column B-Tree NOT UNIQUE indexes that are defined as prefix of another composed index too.

Note.

 1. Sigle B-Tree and NOT UNIQUE indexes are compared wich each
    composed index per table.

 2. Cases where the prefix index is unique are not considered as the uniqueness of the prefix index in this case enforce a constraint not enforced by the composed index.