### PR TITLE
Add the rds-binlog-to-s3.sh script

### DIFF
--- a/mysql/mysql.README
+++ b/mysql/mysql.README
@@ -88,3 +88,9 @@ RDSDatabaseConnection.java	    :   Run as java RDSDatabaseConnection <hostname> 
 rds-support-tools/mysql/diag/proc
 #####################################
 
+
+#####################################
+rds-support-tools/mysql/rds-binlog-to-s3
+#####################################
+rds-binlog-to-s3.sh                 :   Backup RDS/Aurora MySQL binlog to S3 bucket
+                                        Tested on MySQL 5.7

--- a/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
+++ b/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+#Script to download RDS MySQL binlog files using mysqlbinlog command and the AWS CLI tools to upload them to S3.
+#Install AWS CLI tools see: "http://docs.aws.amazon.com/cli/latest/userguide/installing.html"
+#Config your AWS config File (aws configure)
+AWS_PATH=/opt/aws
+Backup_dir=/home/ec2-user/backup/binlog/$(date "+%Y-%m-%d")
+Bucket='rds-binlogs'
+RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'
+master='admin'
+export MYSQL_PWD='test1234'
+
+mysql_binlog_filename=$(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}')
+
+for file in $mysql_binlog_filename
+do
+        if ! test -d $Backup_dir
+        then
+                mkdir $Backup_dir
+        fi
+        #remote read binlog
+        `mysqlbinlog -u $master -h $RDS --read-from-remote-server $file --result-file=$Backup_dir/$file`
+done
+
+# Upload to S3 bucket: aws-tinglinc-logs
+aws s3 sync $Backup_dir s3://$Bucket/binlog
+
+# Clean binlog on disk 1 day ago
+`find /home/ec2-user/backup/binlog -mtime +1 -name "mysql-bin-changelog.*" -exec rm -rf {} \;`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
many Mandarin customers want backup RDS binlogs to S3. So I write a script for download RDS binlog files to S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
