### PR TITLE
logs cannot be converted to binary files

### DIFF
--- a/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
+++ b/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
@@ -19,7 +19,7 @@ do
                 mkdir $Backup_dir
         fi
         #remote read binlog
-        `mysqlbinlog -u $master -h $RDS --read-from-remote-server $file --result-file=$Backup_dir/$file`
+        `mysqlbinlog --raw -u $master -h $RDS --read-from-remote-server $file --result-file=$Backup_dir/$file`
 done
 
 # Upload to S3 bucket


### PR DESCRIPTION
In this example, logs  which exported by this script  are not binary files and cannot be converted to SQL files. You need to add parameter --raw，Thanks

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
