### PR TITLE
Create startTime-createPolicyStatement

### DIFF
--- a/startTime-createPolicyStatement
+++ b/startTime-createPolicyStatement
@@ -1,0 +1,244 @@
+## public static string CreatePolicyStatement(string policyStmnt, 
+   string resourceUrl, 
+   DateTime startTime, 
+   DateTime endTime, 
+   string ipAddress)
+   
+{
+   // Create the policy statement.
+   FileStream streamPolicy = new FileStream(policyStmnt, FileMode.Open, FileAccess.Read);
+   using (StreamReader reader = new StreamReader(streamPolicy))
+   {
+      string strPolicy = reader.ReadToEnd();
+
+      TimeSpan startTimeSpanFromNow = (startTime - DateTime.Now);
+      TimeSpan endTimeSpanFromNow = (endTime - DateTime.Now);
+      TimeSpan intervalStart = 
+         (DateTime.UtcNow.Add(startTimeSpanFromNow)) - 
+         new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+      TimeSpan intervalEnd = 
+         (DateTime.UtcNow.Add(endTimeSpanFromNow)) - 
+         new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+      int startTimestamp = (int)intervalStart.TotalSeconds; // START_TIME
+      int endTimestamp = (int)intervalEnd.TotalSeconds;  // END_TIME
+
+      if (startTimestamp > endTimestamp)
+         return "Error!";
+
+      // Replace variables in the policy statement.
+      strPolicy = strPolicy.Replace("RESOURCE", resourceUrl);
+      strPolicy = strPolicy.Replace("START_TIME", startTimestamp.ToString());
+      strPolicy = strPolicy.Replace("END_TIME", endTimestamp.ToString());
+      strPolicy = strPolicy.Replace("IP_ADDRESS", ipAddress);
+      strPolicy = strPolicy.Replace("EXPIRES", endTimestamp.ToString());
+      return strPolicy;
+   }   
+}
+
+public static TimeSpan GetDuration(string units, string numUnits)
+{
+   TimeSpan timeSpanInterval = new TimeSpan();
+   switch (units)
+   {
+      case "seconds":
+         timeSpanInterval = new TimeSpan(0, 0, 0, int.Parse(numUnits));
+         break;
+      case "minutes":
+         timeSpanInterval = new TimeSpan(0, 0, int.Parse(numUnits), 0);
+         break;
+      case "hours":
+         timeSpanInterval = new TimeSpan(0, int.Parse(numUnits), 0 ,0);
+         break;
+      case "days":
+         timeSpanInterval = new TimeSpan(int.Parse(numUnits),0 ,0 ,0);
+         break;
+      default:
+         Console.WriteLine("Invalid time units;" + 
+            "use seconds, minutes, hours, or days");
+         break;
+   }
+   return timeSpanInterval;
+}
+
+## private static TimeSpan GetDurationByUnits(string durationUnits, 
+   string startIntervalFromNow)
+{
+   switch (durationUnits)
+   {
+      case "seconds":
+         return new TimeSpan(0, 0, int.Parse(startIntervalFromNow));
+      case "minutes":
+         return new TimeSpan(0, int.Parse(startIntervalFromNow), 0);
+      case "hours":
+         return new TimeSpan(int.Parse(startIntervalFromNow), 0, 0);
+      case "days":
+         return new TimeSpan(int.Parse(startIntervalFromNow), 0, 0, 0);
+      default:
+         return new TimeSpan(0, 0, 0, 0);
+   }
+}
+
+public static string CopyExpirationTimeFromPolicy(string policyStatement)
+{
+   int startExpiration = policyStatement.IndexOf("EpochTime");
+   string strExpirationRough = policyStatement.Substring(startExpiration + 
+      "EpochTime".Length);
+   char[] digits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+         
+   List<char> listDigits = new List<char>(digits);
+   StringBuilder buildExpiration = new StringBuilder(20);
+         
+   foreach (char c in strExpirationRough)
+   {
+      if (listDigits.Contains(c))
+         buildExpiration.Append(c);
+   }
+   return buildExpiration.ToString();   
+}TimeSpan(int.Parse(numUnits),0 ,0 ,0)
+public static string ToUrlSafeBase64String(byte[] bytes)
+{
+    return System.Convert.ToBase64String(bytes)
+        .Replace('+', '-')
+        .Replace('=', '_')
+        .Replace('/', '~');
+}
+
+public static string CreateCustomPrivateURL(string urlString, 
+    string durationUnits, string durationNumber, string startIntervalFromNow, 
+    string ipaddress, string pathToPolicyStmnt, string pathToPrivateKey, 
+    string keyId)
+{
+    // args[] 0-thisMethod, 1-resourceUrl, 2-seconds-minutes-hours-days 
+    // to expiration, 3-numberOfPreviousUnits, 4-starttimeFromNow, 
+    // 5-ip_address, 6-pathToPolicyStmt, 7-pathToPrivateKey, 8-keyId
+
+    TimeSpan timeSpanInterval = GetDuration(durationUnits, durationNumber);
+    TimeSpan timeSpanToStart = GetDurationByUnits(durationUnits, 
+        startIntervalFromNow);
+    if (null == timeSpanToStart) 
+        return "Invalid duration units." + 
+            "Valid options: seconds, minutes, hours, or days";
+            
+    string strPolicy = CreatePolicyStatement(
+        pathToPolicyStmnt, urlString, DateTime.Now.Add(timeSpanToStart), 
+        DateTime.Now.Add(timeSpanInterval), ipaddress);
+
+    // Read the policy into a byte buffer.
+    byte[] bufferPolicy = Encoding.ASCII.GetBytes(strPolicy);
+
+    // Convert the policy statement to URL-safe base64 encoding and 
+    // replace unsafe characters + = / with the safe characters - _ ~
+
+    string urlSafePolicy = ToUrlSafeBase64String(bufferPolicy);
+
+    // Initialize the SHA1CryptoServiceProvider object and hash the policy data.
+    byte[] bufferPolicyHash;
+    using (SHA1CryptoServiceProvider cryptoSHA1 = 
+        new SHA1CryptoServiceProvider())
+    {
+        bufferPolicyHash = cryptoSHA1.ComputeHash(bufferPolicy);
+
+        // Initialize the RSACryptoServiceProvider object.
+        RSACryptoServiceProvider providerRSA = new RSACryptoServiceProvider();
+        XmlDocument xmlPrivateKey = new XmlDocument();
+
+        // Load your private key, which you created by converting your 
+        // .pem file to the XML format that the .NET framework uses.  
+        // Several tools are available. 
+        xmlPrivateKey.Load(pathToPrivateKey);
+
+        // Format the RSACryptoServiceProvider providerRSA 
+        // and create the signature.
+        providerRSA.FromXmlString(xmlPrivateKey.InnerXml);
+        RSAPKCS1SignatureFormatter RSAFormatter = 
+            new RSAPKCS1SignatureFormatter(providerRSA);
+        RSAFormatter.SetHashAlgorithm("SHA1");
+        byte[] signedHash = RSAFormatter.CreateSignature(bufferPolicyHash);
+
+        // Convert the signed policy to URL-safe base64 encoding and 
+        // replace unsafe characters + = / with the safe characters - _ ~
+        string strSignedPolicy = ToUrlSafeBase64String(signedHash);
+
+        return urlString + 
+            "?Policy=" + 
+            urlSafePolicy + 
+            "&Signature=" + 
+            strSignedPolicy + 
+            "&Key-Pair-Id=" + 
+            keyId;
+    }
+}
+
+## public static string ToUrlSafeBase64String(byte[] bytes)
+{
+    return System.Convert.ToBase64String(bytes)
+        .Replace('+', '-')
+        .Replace('=', '_')
+        .Replace('/', '~');
+}
+
+public static string CreateCannedPrivateURL(string urlString, 
+    string durationUnits, string durationNumber, string pathToPolicyStmnt, 
+    string pathToPrivateKey, string keyId)
+{
+    // args[] 0-thisMethod, 1-resourceUrl, 2-seconds-minutes-hours-days 
+    // to expiration, 3-numberOfPreviousUnits, 4-pathToPolicyStmnt, 
+    // 5-pathToPrivateKey, 6-keyId
+
+    TimeSpan timeSpanInterval = GetDuration(durationUnits, durationNumber);
+
+    // Create the policy statement.
+    string strPolicy = CreatePolicyStatement(pathToPolicyStmnt,
+        urlString, 
+        DateTime.Now, 
+        DateTime.Now.Add(timeSpanInterval), 
+        "0.0.0.0/0");
+    if ("Error!" == strPolicy) return "Invalid time frame." + 
+        "Start time cannot be greater than end time.";
+
+    // Copy the expiration time defined by policy statement.
+    string strExpiration = CopyExpirationTimeFromPolicy(strPolicy);
+
+    // Read the policy into a byte buffer.
+    byte[] bufferPolicy = Encoding.ASCII.GetBytes(strPolicy);
+
+    // Initialize the SHA1CryptoServiceProvider object and hash the policy data.
+    using (SHA1CryptoServiceProvider 
+        cryptoSHA1 = new SHA1CryptoServiceProvider())
+    {
+        bufferPolicy = cryptoSHA1.ComputeHash(bufferPolicy);
+
+        // Initialize the RSACryptoServiceProvider object.
+        RSACryptoServiceProvider providerRSA = new RSACryptoServiceProvider();
+        XmlDocument xmlPrivateKey = new XmlDocument();
+
+        // Load your private key, which you created by converting your 
+        // .pem file to the XML format that the .NET framework uses.  
+        // Several tools are available. 
+        xmlPrivateKey.Load(pathToPrivateKey);
+
+        // Format the RSACryptoServiceProvider providerRSA and 
+        // create the signature.
+        providerRSA.FromXmlString(xmlPrivateKey.InnerXml);
+        RSAPKCS1SignatureFormatter rsaFormatter = 
+            new RSAPKCS1SignatureFormatter(providerRSA);
+        rsaFormatter.SetHashAlgorithm("SHA1");
+        byte[] signedPolicyHash = rsaFormatter.CreateSignature(bufferPolicy);
+
+        // Convert the signed policy to URL-safe base64 encoding and 
+        // replace unsafe characters + = / with the safe characters - _ ~
+        string strSignedPolicy = ToUrlSafeBase64String(signedPolicyHash);
+
+        // Concatenate the URL, the timestamp, the signature, 
+        // and the key pair ID to form the signed URL.
+        return urlString + 
+            "?Expires=" + 
+            strExpiration + 
+            "&Signature=" + 
+            strSignedPolicy + 
+            "&Key-Pair-Id=" + 
+            keyId;
+    }
+}
+## ```https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html#private-content-choosing-canned-custom-policy```


### PR DESCRIPTION
## public static string CreatePolicyStatement(string policyStmnt, 
   string resourceUrl, 
   DateTime startTime, 
   DateTime endTime, 
   string ipAddress)
   
{
   // Create the policy statement.
   FileStream streamPolicy = new FileStream(policyStmnt, FileMode.Open, FileAccess.Read);
   using (StreamReader reader = new StreamReader(streamPolicy))
   {
      string strPolicy = reader.ReadToEnd();

      TimeSpan startTimeSpanFromNow = (startTime - DateTime.Now);
      TimeSpan endTimeSpanFromNow = (endTime - DateTime.Now);
      TimeSpan intervalStart = 
         (DateTime.UtcNow.Add(startTimeSpanFromNow)) - 
         new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
      TimeSpan intervalEnd = 
         (DateTime.UtcNow.Add(endTimeSpanFromNow)) - 
         new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);

      int startTimestamp = (int)intervalStart.TotalSeconds; // START_TIME
      int endTimestamp = (int)intervalEnd.TotalSeconds;  // END_TIME

      if (startTimestamp > endTimestamp)
         return "Error!";

      // Replace variables in the policy statement.
      strPolicy = strPolicy.Replace("RESOURCE", resourceUrl);
      strPolicy = strPolicy.Replace("START_TIME", startTimestamp.ToString());
      strPolicy = strPolicy.Replace("END_TIME", endTimestamp.ToString());
      strPolicy = strPolicy.Replace("IP_ADDRESS", ipAddress);
      strPolicy = strPolicy.Replace("EXPIRES", endTimestamp.ToString());
      return strPolicy;
   }   
}

public static TimeSpan GetDuration(string units, string numUnits) {
   TimeSpan timeSpanInterval = new TimeSpan();
   switch (units)
   {
      case "seconds":
         timeSpanInterval = new TimeSpan(0, 0, 0, int.Parse(numUnits));
         break;
      case "minutes":
         timeSpanInterval = new TimeSpan(0, 0, int.Parse(numUnits), 0);
         break;
      case "hours":
         timeSpanInterval = new TimeSpan(0, int.Parse(numUnits), 0 ,0);
         break;
      case "days":
         timeSpanInterval = new TimeSpan(int.Parse(numUnits),0 ,0 ,0);
         break;
      default:
         Console.WriteLine("Invalid time units;" + 
            "use seconds, minutes, hours, or days");
         break;
   }
   return timeSpanInterval;
}

## private static TimeSpan GetDurationByUnits(string durationUnits, 
   string startIntervalFromNow)
{
   switch (durationUnits)
   {
      case "seconds":
         return new TimeSpan(0, 0, int.Parse(startIntervalFromNow));
      case "minutes":
         return new TimeSpan(0, int.Parse(startIntervalFromNow), 0);
      case "hours":
         return new TimeSpan(int.Parse(startIntervalFromNow), 0, 0);
      case "days":
         return new TimeSpan(int.Parse(startIntervalFromNow), 0, 0, 0);
      default:
         return new TimeSpan(0, 0, 0, 0);
   }
}

public static string CopyExpirationTimeFromPolicy(string policyStatement) {
   int startExpiration = policyStatement.IndexOf("EpochTime");
   string strExpirationRough = policyStatement.Substring(startExpiration + 
      "EpochTime".Length);
   char[] digits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
         
   List<char> listDigits = new List<char>(digits);
   StringBuilder buildExpiration = new StringBuilder(20);
         
   foreach (char c in strExpirationRough)
   {
      if (listDigits.Contains(c))
         buildExpiration.Append(c);
   }
   return buildExpiration.ToString();   
}TimeSpan(int.Parse(numUnits),0 ,0 ,0)
public static string ToUrlSafeBase64String(byte[] bytes) {
    return System.Convert.ToBase64String(bytes)
        .Replace('+', '-')
        .Replace('=', '_')
        .Replace('/', '~');
}

public static string CreateCustomPrivateURL(string urlString, 
    string durationUnits, string durationNumber, string startIntervalFromNow, 
    string ipaddress, string pathToPolicyStmnt, string pathToPrivateKey, 
    string keyId)
{
    // args[] 0-thisMethod, 1-resourceUrl, 2-seconds-minutes-hours-days 
    // to expiration, 3-numberOfPreviousUnits, 4-starttimeFromNow, 
    // 5-ip_address, 6-pathToPolicyStmt, 7-pathToPrivateKey, 8-keyId

    TimeSpan timeSpanInterval = GetDuration(durationUnits, durationNumber);
    TimeSpan timeSpanToStart = GetDurationByUnits(durationUnits, 
        startIntervalFromNow);
    if (null == timeSpanToStart) 
        return "Invalid duration units." + 
            "Valid options: seconds, minutes, hours, or days";
            
    string strPolicy = CreatePolicyStatement(
        pathToPolicyStmnt, urlString, DateTime.Now.Add(timeSpanToStart), 
        DateTime.Now.Add(timeSpanInterval), ipaddress);

    // Read the policy into a byte buffer.
    byte[] bufferPolicy = Encoding.ASCII.GetBytes(strPolicy);

    // Convert the policy statement to URL-safe base64 encoding and 
    // replace unsafe characters + = / with the safe characters - _ ~

    string urlSafePolicy = ToUrlSafeBase64String(bufferPolicy);

    // Initialize the SHA1CryptoServiceProvider object and hash the policy data.
    byte[] bufferPolicyHash;
    using (SHA1CryptoServiceProvider cryptoSHA1 = 
        new SHA1CryptoServiceProvider())
    {
        bufferPolicyHash = cryptoSHA1.ComputeHash(bufferPolicy);

        // Initialize the RSACryptoServiceProvider object.
        RSACryptoServiceProvider providerRSA = new RSACryptoServiceProvider();
        XmlDocument xmlPrivateKey = new XmlDocument();

        // Load your private key, which you created by converting your 
        // .pem file to the XML format that the .NET framework uses.  
        // Several tools are available. 
        xmlPrivateKey.Load(pathToPrivateKey);

        // Format the RSACryptoServiceProvider providerRSA 
        // and create the signature.
        providerRSA.FromXmlString(xmlPrivateKey.InnerXml);
        RSAPKCS1SignatureFormatter RSAFormatter = 
            new RSAPKCS1SignatureFormatter(providerRSA);
        RSAFormatter.SetHashAlgorithm("SHA1");
        byte[] signedHash = RSAFormatter.CreateSignature(bufferPolicyHash);

        // Convert the signed policy to URL-safe base64 encoding and 
        // replace unsafe characters + = / with the safe characters - _ ~
        string strSignedPolicy = ToUrlSafeBase64String(signedHash);

        return urlString + 
            "?Policy=" + 
            urlSafePolicy + 
            "&Signature=" + 
            strSignedPolicy + 
            "&Key-Pair-Id=" + 
            keyId;
    }
}

## public static string ToUrlSafeBase64String(byte[] bytes) {
    return System.Convert.ToBase64String(bytes)
        .Replace('+', '-')
        .Replace('=', '_')
        .Replace('/', '~');
}

public static string CreateCannedPrivateURL(string urlString, 
    string durationUnits, string durationNumber, string pathToPolicyStmnt, 
    string pathToPrivateKey, string keyId)
{
    // args[] 0-thisMethod, 1-resourceUrl, 2-seconds-minutes-hours-days 
    // to expiration, 3-numberOfPreviousUnits, 4-pathToPolicyStmnt, 
    // 5-pathToPrivateKey, 6-keyId

    TimeSpan timeSpanInterval = GetDuration(durationUnits, durationNumber);

    // Create the policy statement.
    string strPolicy = CreatePolicyStatement(pathToPolicyStmnt,
        urlString, 
        DateTime.Now, 
        DateTime.Now.Add(timeSpanInterval), 
        "0.0.0.0/0");
    if ("Error!" == strPolicy) return "Invalid time frame." + 
        "Start time cannot be greater than end time.";

    // Copy the expiration time defined by policy statement.
    string strExpiration = CopyExpirationTimeFromPolicy(strPolicy);

    // Read the policy into a byte buffer.
    byte[] bufferPolicy = Encoding.ASCII.GetBytes(strPolicy);

    // Initialize the SHA1CryptoServiceProvider object and hash the policy data.
    using (SHA1CryptoServiceProvider 
        cryptoSHA1 = new SHA1CryptoServiceProvider())
    {
        bufferPolicy = cryptoSHA1.ComputeHash(bufferPolicy);

        // Initialize the RSACryptoServiceProvider object.
        RSACryptoServiceProvider providerRSA = new RSACryptoServiceProvider();
        XmlDocument xmlPrivateKey = new XmlDocument();

        // Load your private key, which you created by converting your 
        // .pem file to the XML format that the .NET framework uses.  
        // Several tools are available. 
        xmlPrivateKey.Load(pathToPrivateKey);

        // Format the RSACryptoServiceProvider providerRSA and 
        // create the signature.
        providerRSA.FromXmlString(xmlPrivateKey.InnerXml);
        RSAPKCS1SignatureFormatter rsaFormatter = 
            new RSAPKCS1SignatureFormatter(providerRSA);
        rsaFormatter.SetHashAlgorithm("SHA1");
        byte[] signedPolicyHash = rsaFormatter.CreateSignature(bufferPolicy);

        // Convert the signed policy to URL-safe base64 encoding and 
        // replace unsafe characters + = / with the safe characters - _ ~
        string strSignedPolicy = ToUrlSafeBase64String(signedPolicyHash);

        // Concatenate the URL, the timestamp, the signature, 
        // and the key pair ID to form the signed URL.
        return urlString + 
            "?Expires=" + 
            strExpiration + 
            "&Signature=" + 
            strSignedPolicy + 
            "&Key-Pair-Id=" + 
            keyId;
    }
}
## ```https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html#private-content-choosing-canned-custom-policy```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
