### PR TITLE
Add migrate_param_group.sh script

### DIFF
--- a/mysql/rds-binlog-to-s3/README.md
+++ b/mysql/rds-binlog-to-s3/README.md
@@ -1,0 +1,89 @@
+# RDS MySQL Binary Log Backup to S3
+
+Download binary log files from an Amazon RDS MySQL instance and upload them to Amazon S3 on a scheduled basis.
+
+## Overview
+
+This script automates the process of:
+
+1. Connecting to an RDS MySQL instance and listing available binary logs
+2. Downloading each binary log using `mysqlbinlog --read-from-remote-server`
+3. Uploading the downloaded files to an S3 bucket using `aws s3 sync`
+4. Cleaning up local binlog files older than 1 day
+
+Binary log backups are useful for point-in-time recovery beyond the RDS automated backup retention period, compliance and audit requirements, and disaster recovery to a different region or account.
+
+> **Note:** The script excludes the last (most recent) binary log from the download because it may still be actively written to by the MySQL server, which would result in an incomplete file. See [issue #84](https://github.com/awslabs/rds-support-tools/issues/84).
+
+For more details, see [How can I schedule uploads of Amazon RDS MySQL binary logs to Amazon S3?](https://repost.aws/knowledge-center/rds-mysql-schedule-binlog-uploads)
+
+## Prerequisites
+
+- An EC2 instance (or similar host) with network access to the RDS MySQL instance
+- MySQL client (`mysql` and `mysqlbinlog` commands)
+- AWS CLI configured with permissions to write to the target S3 bucket (`aws configure`)
+- An RDS MySQL user with `REPLICATION SLAVE` privilege
+
+## Setup
+
+1. Edit the script variables to match your environment:
+
+```bash
+Backup_dir=/home/ec2-user/backup/binlog/$(date "+%Y-%m-%d")
+Bucket='rds-binlogs'                                          # S3 bucket name
+RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'          # RDS endpoint
+master='admin'                                                 # MySQL username
+export MYSQL_PWD='your_password'                               # MySQL password
+```
+
+> **Security:** Avoid hardcoding passwords in the script. Consider using AWS Secrets Manager, a `.my.cnf` file with restricted permissions, or environment variables instead.
+
+2. Make the script executable:
+
+```bash
+chmod +x rds-binlog-to-s3.sh
+```
+
+3. Test manually:
+
+```bash
+./rds-binlog-to-s3.sh
+```
+
+4. Schedule with cron (e.g., every hour):
+
+```bash
+crontab -e
+# Add:
+0 * * * * /path/to/rds-binlog-to-s3.sh >> /var/log/binlog-backup.log 2>&1
+```
+
+## How It Works
+
+```
+RDS MySQL Instance
+       │
+       │  SHOW MASTER LOGS
+       ▼
+  List binary log files
+  (exclude last — may be incomplete)
+       │
+       │  mysqlbinlog --read-from-remote-server
+       ▼
+  Local backup directory
+  /home/ec2-user/backup/binlog/YYYY-MM-DD/
+       │
+       │  aws s3 sync
+       ▼
+  s3://rds-binlogs/binlog/
+       │
+       │  find -mtime +1 -exec rm
+       ▼
+  Clean up local files older than 1 day
+```
+
+## Additional Resources
+
+- [Working with MySQL Binary Logs on RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html)
+- [mysqlbinlog — Utility for Processing Binary Log Files](https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html)
+- [AWS CLI S3 sync](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html)

--- a/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
+++ b/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
@@ -10,9 +10,12 @@ RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'
 master='admin'
 export MYSQL_PWD='test1234'
 
-mysql_binlog_filename=$(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}')
+# Converting to array — the last binary log may still be actively written
+# to by the master, so we exclude it to avoid downloading incomplete data.
+# See: https://github.com/awslabs/rds-support-tools/issues/84
+mysql_binlog_filename=($(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}'))
 
-for file in $mysql_binlog_filename
+for file in ${mysql_binlog_filename[@]::${#mysql_binlog_filename[@]}-1}
 do
         if ! test -d $Backup_dir
         then

--- a/parameter-migrate/README.md
+++ b/parameter-migrate/README.md
@@ -1,0 +1,243 @@
+# Migrate Amazon RDS Parameter Group
+
+Automate parameter group migration across engine versions, engine types (RDS ↔ Aurora), and AWS regions using the AWS CLI.
+
+## Overview
+
+Migrating database parameter group settings is one of the most common operational tasks when performing:
+
+- Engine version upgrades (e.g., RDS MySQL 5.7 → 8.0, PostgreSQL 14 → 15)
+- Migration to Aurora (e.g., RDS MySQL → Aurora MySQL 3, RDS PostgreSQL → Aurora PostgreSQL)
+- Cross-region disaster recovery setup (copy parameter group to another region)
+
+Without automation, engineers must manually identify, compare, and re-apply every modified parameter — a process that is tedious, error-prone, and time-consuming, especially for databases with hundreds of customized parameters.
+
+A missing or misconfigured parameter can cause performance degradation, application errors, or security compliance violations. This is compounded by the fact that:
+
+- Parameters valid in one engine version may not exist in another
+- Some parameters behave differently across engines (e.g., RDS MySQL vs Aurora MySQL)
+- Aurora cluster parameter groups have a different structure from RDS instance parameter groups
+- Certain parameters require prerequisites before they can be applied (e.g., `innodb_flush_log_at_trx_commit` in Aurora MySQL 3)
+
+| | Manual Approach | This Script |
+|---|---|---|
+| Method | Console UI — one by one | AWS CLI — fully automated |
+| Time | Hours for large groups | Minutes |
+| Error risk | High — easy to miss parameters | Low — automated validation |
+| Compatibility check | Manual — check docs per parameter | Automatic — API-driven |
+| Cross-region | Not straightforward | Built-in support |
+| Audit trail | None | Full migration report |
+
+> **⚠️ Important: Always Review Parameters Before Applying**
+>
+> This script automates parameter migration as a starting point — not a final configuration.
+> Carrying over parameters as-is when upgrading or changing the engine type is not a best practice.
+> Parameters may behave differently depending on the target engine version or type.
+>
+> Before applying migrated parameters to a production database:
+> - Review the migration report (APPLIED, SKIPPED, INCOMPATIBLE, and FAILED sections)
+> - Verify each applied parameter is appropriate for the target engine
+> - Test in a non-production environment first
+> - Consult engine-specific documentation — parameter semantics can differ between RDS and Aurora, or between major versions
+
+## Common Use Cases
+
+| Source | Target |
+|---|---|
+| RDS PostgreSQL | Aurora PostgreSQL |
+| Aurora PostgreSQL | RDS PostgreSQL |
+| RDS MySQL | Aurora MySQL |
+| Aurora MySQL | RDS MySQL |
+| RDS MariaDB | Aurora MySQL |
+| Any engine (same version) | Same engine (cross-region copy) |
+| Any engine | Same engine (version upgrade) |
+
+> **Note:** The script uses the AWS API `IsModifiable` flag to determine what can be applied.
+> Parameters not found in the target engine are reported as INCOMPATIBLE.
+> Parameters found but not modifiable are reported as SKIPPED.
+> Parameters rejected by the API are reported as FAILED with the error reason.
+
+## How It Works
+
+```
+Source Parameter Group                    Target Parameter Group
+(user-modified params only)               (new version / new engine)
+         │                                          │
+         │  export_params()                         │  create_target_group()
+         ▼                                          ▼
+  source_params.json          ──────►   target_valid_params.json
+         │                    filter           │
+         │                    _params()        │
+         ▼                                     ▼
+  ┌─────────────┐   ┌─────────────┐   ┌──────────────────┐
+  │  APPLICABLE │   │   SKIPPED   │   │   INCOMPATIBLE   │
+  │             │   │             │   │                  │
+  │ Found in    │   │ Found in    │   │ Not found in     │
+  │ target AND  │   │ target BUT  │   │ target engine    │
+  │ modifiable  │   │ not         │   │ at all           │
+  └──────┬──────┘   │ modifiable  │   └──────────────────┘
+         │          └─────────────┘
+         ▼
+  apply_params() ── batch apply
+         │
+         ├── ✅ Success → APPLIED
+         │
+         └── ❌ Batch fail → retry individually
+                   │
+                   ├── ✅ Success → APPLIED
+                   ├── 🔄 Has prerequisite → apply prereq → retry → APPLIED
+                   └── ❌ Still fail → FAILED (with reason)
+```
+
+## Prerequisites
+
+- AWS CLI v2 ([install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html))
+- jq ([download](https://jqlang.github.io/jq/download/))
+- AWS credentials configured (`aws configure`)
+
+```bash
+# Verify
+aws --version && jq --version
+```
+
+## Usage
+
+```bash
+chmod +x migrate_param_group.sh
+
+./migrate_param_group.sh -s <source_group> -t <target_group> -f <target_family> [options]
+```
+
+### Options
+
+| Flag | Description | Required | Default |
+|------|-------------|----------|---------|
+| `-s` | Source parameter group name | Yes | — |
+| `-t` | Target parameter group name | Yes | — |
+| `-f` | Target parameter group family | Yes | — |
+| `-S` | Source AWS region | No | AWS CLI configured region |
+| `-T` | Target AWS region | No | AWS CLI configured region |
+| `-b` | Batch size for apply operations | No | 20 |
+| `-n` | Dry run (no changes applied) | No | — |
+
+### Examples
+
+```bash
+# RDS PostgreSQL → Aurora PostgreSQL (same region)
+./migrate_param_group.sh \
+  -s my-rds-pg15 \
+  -t my-aurora-pg15-cluster \
+  -f aurora-postgresql15
+
+# RDS MySQL → Aurora MySQL (same region)
+./migrate_param_group.sh \
+  -s my-rds-mysql80 \
+  -t my-aurora-mysql80-cluster \
+  -f aurora-mysql8.0
+
+# Cross-region copy (same engine)
+./migrate_param_group.sh \
+  -s my-rds-pg15 \
+  -t my-rds-pg15-copy \
+  -f postgres15 \
+  -S us-east-1 \
+  -T ap-southeast-1
+
+# Cross-region with engine migration
+./migrate_param_group.sh \
+  -s my-rds-pg15 \
+  -t my-aurora-pg15-cluster \
+  -f aurora-postgresql15 \
+  -S us-east-1 \
+  -T ap-southeast-1
+
+# Dry run (preview only, no changes)
+./migrate_param_group.sh \
+  -s my-rds-pg15 \
+  -t my-aurora-pg15-cluster \
+  -f aurora-postgresql15 \
+  -n
+```
+
+## Output
+
+The script creates a timestamped directory with all artifacts:
+
+```
+migration_20260331_084920/
+├── source_params.json         # Exported source parameters (user-modified only)
+├── target_valid_params.json   # All valid parameters in target engine
+├── params_applicable.json     # Parameters applied to target
+├── params_skipped.json        # Found in target but not modifiable
+├── params_incompatible.json   # Not found in target engine
+├── params_failed.json         # API rejected — review required
+└── migration_report.txt       # Full migration report
+```
+
+## Sample Output
+
+### Successful Migration (Aurora MySQL → RDS MySQL, same region)
+
+```
+============================================================
+  PARAMETER GROUP MIGRATION REPORT
+  Date    : Tue Mar 31 08:49:29 UTC 2026
+  DryRun  : false
+============================================================
+  Source  : ams303 [aurora-mysql8.0 | cluster | us-west-2]
+  Target  : mysql84 [mysql8.4 | instance | us-west-2]
+------------------------------------------------------------
+  Total Exported  : 10
+  Applied         : 6
+  Skipped         : 0
+  Incompatible    : 4
+  Failed          : 0
+============================================================
+```
+
+### Cross-Region Copy (Aurora PostgreSQL → RDS PostgreSQL)
+
+```
+============================================================
+  PARAMETER GROUP MIGRATION REPORT
+  Date    : Tue Mar 31 08:46:28 UTC 2026
+  DryRun  : false
+============================================================
+  Source  : apg16 [aurora-postgresql16 | instance | us-west-2]
+  Target  : pg17 [postgres17 | instance | us-east-1]
+------------------------------------------------------------
+  Total Exported  : 1
+  Applied         : 1
+  Skipped         : 0
+  Incompatible    : 0
+  Failed          : 0
+============================================================
+```
+
+### Target Group Already Exists (script stops)
+
+```
+=== Step 3: Create Target Parameter Group ===
+[ERROR] Failed to create parameter group: mysql84
+[ERROR] Reason: An error occurred (DBParameterGroupAlreadyExists) when calling
+        the CreateDBParameterGroup operation: Parameter group mysql84 already exists
+```
+
+## Parameter Prerequisite Handling
+
+Some parameters require other parameters to be set first. The script handles this automatically.
+
+For example, when migrating `innodb_flush_log_at_trx_commit` from RDS MySQL (which supports values 0, 1, 2) to Aurora MySQL 3 (which only supports 0 or 1):
+
+1. The script detects the source value is not 1 (e.g., value is 2)
+2. Applies the prerequisite: `innodb_trx_commit_allow_data_loss = 1`
+3. Applies the parameter with an overridden value: `innodb_flush_log_at_trx_commit = 0`
+
+Additional prerequisites can be added to the `PARAM_PREREQUISITES` array in the script.
+
+## Additional Resources
+
+- [Working with DB Parameter Groups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
+- [Aurora PostgreSQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterFiles.html)
+- [Aurora MySQL Parameters](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.ParameterGroups.html)
+- [AWS CLI RDS Reference](https://docs.aws.amazon.com/cli/latest/reference/rds/)

--- a/parameter-migrate/migrate_param_group.sh
+++ b/parameter-migrate/migrate_param_group.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# migrate_param_group.sh
+#
+# Usage:
+#   ./migrate_param_group.sh -s <source_group> -t <target_group> -f <target_family> [-S source_region] [-T target_region] [-b batch_size] [-n]
+#
+# Options:
+#   -s  Source parameter group name   (required)
+#   -t  Target parameter group name   (required)
+#   -f  Target parameter group family (required)
+#   -S  Source AWS region             (default: AWS CLI configured region)
+#   -T  Target AWS region             (default: AWS CLI configured region)
+#   -b  Batch size                    (default: 20)
+#   -n  Dry run
+#
+# Examples:
+#   ./migrate_param_group.sh -s my-rds-pg15 -t my-aurora-pg15 -f aurora-postgresql15
+#   ./migrate_param_group.sh -s my-rds-mysql80 -t my-aurora-mysql80 -f aurora-mysql8.0
+#   ./migrate_param_group.sh -s my-rds-pg15 -t my-rds-pg15-copy -f postgres15 -S us-east-1 -T ap-southeast-1
+#   ./migrate_param_group.sh -s my-rds-pg15 -t my-aurora-pg15 -f aurora-postgresql15 -n
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────
+CLI_REGION=$(aws configure get region 2>/dev/null || echo "us-east-1")
+SOURCE_REGION="${CLI_REGION}"
+TARGET_REGION="${CLI_REGION}"
+BATCH_SIZE=20
+DRY_RUN=false
+
+# ── Colors ────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'
+YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log_info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*"; }
+log_section() { echo -e "\n${BLUE}=== $* ===${NC}"; }
+
+# ── Parse Args ────────────────────────────────────────────
+while getopts "s:t:f:S:T:b:nh" opt; do
+  case ${opt} in
+    s) SOURCE_PARAM_GROUP="${OPTARG}" ;;
+    t) TARGET_PARAM_GROUP="${OPTARG}" ;;
+    f) TARGET_FAMILY="${OPTARG}"      ;;
+    S) SOURCE_REGION="${OPTARG}"      ;;
+    T) TARGET_REGION="${OPTARG}"      ;;
+    b) BATCH_SIZE="${OPTARG}"         ;;
+    n) DRY_RUN=true                   ;;
+    *) grep "^#" "$0" | sed 's/^# \?//'; exit 1 ;;
+  esac
+done
+
+if [[ -z "${SOURCE_PARAM_GROUP:-}" || \
+      -z "${TARGET_PARAM_GROUP:-}" || \
+      -z "${TARGET_FAMILY:-}" ]]; then
+  log_error "Missing required arguments: -s, -t, -f"
+  exit 1
+fi
+
+# ── Working Directory ─────────────────────────────────────
+WORK_DIR="migration_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "${WORK_DIR}"
+EXPORT_FILE="${WORK_DIR}/source_params.json"
+TARGET_VALID_FILE="${WORK_DIR}/target_valid_params.json"
+APPLICABLE_FILE="${WORK_DIR}/params_applicable.json"
+SKIPPED_FILE="${WORK_DIR}/params_skipped.json"
+INCOMPATIBLE_FILE="${WORK_DIR}/params_incompatible.json"
+FAILED_FILE="${WORK_DIR}/params_failed.json"
+REPORT_FILE="${WORK_DIR}/migration_report.txt"
+FAILED_TMP="${WORK_DIR}/.params_failed_tmp.json"
+echo '[]' > "${FAILED_TMP}"
+
+# ── Parameter Prerequisites ───────────────────────────────
+# Format: "param_name:condition:prereq_name:prereq_value:prereq_method:override_value"
+#
+# param_name    : parameter to check
+# condition     : "ne1" = apply only when source value != 1
+# prereq_name   : prerequisite parameter to apply first
+# prereq_value  : prerequisite parameter value
+# prereq_method : apply method for prerequisite
+# override_value: value to use instead of original source value
+#
+# innodb_flush_log_at_trx_commit:
+#   - If source value != 1 (e.g. 0 or 2 from standard MySQL)
+#   - Aurora MySQL 3 only supports 0 or 1 (not 2)
+#   - Step 1: set innodb_trx_commit_allow_data_loss = 1
+#   - Step 2: set innodb_flush_log_at_trx_commit = 0
+
+PARAM_PREREQUISITES=(
+  "innodb_flush_log_at_trx_commit:ne1:innodb_trx_commit_allow_data_loss:1:pending-reboot:0"
+)
+
+# ── Engine Helpers ────────────────────────────────────────
+
+detect_group_type() {
+  # $1 = group name, $2 = region
+  aws rds describe-db-cluster-parameter-groups \
+    --db-cluster-parameter-group-name "$1" \
+    --region "$2" --output json > /dev/null 2>&1 \
+    && echo "cluster" && return
+  aws rds describe-db-parameter-groups \
+    --db-parameter-group-name "$1" \
+    --region "$2" --output json > /dev/null 2>&1 \
+    && echo "instance" && return
+  echo "not_found"
+}
+
+target_group_type_from_family() {
+  case "$1" in
+    aurora-postgresql*|aurora-mysql*) echo "cluster"  ;;
+    *)                                echo "instance" ;;
+  esac
+}
+
+get_source_family() {
+  # $1 = group name, $2 = group type, $3 = region
+  if [[ "$2" == "cluster" ]]; then
+    aws rds describe-db-cluster-parameter-groups \
+      --db-cluster-parameter-group-name "$1" --region "$3" \
+      --query 'DBClusterParameterGroups[0].DBParameterGroupFamily' --output text
+  else
+    aws rds describe-db-parameter-groups \
+      --db-parameter-group-name "$1" --region "$3" \
+      --query 'DBParameterGroups[0].DBParameterGroupFamily' --output text
+  fi
+}
+
+# ── Export / Fetch ────────────────────────────────────────
+
+export_params() {
+  # $1 = group name, $2 = group type, $3 = region
+  if [[ "$2" == "cluster" ]]; then
+    aws rds describe-db-cluster-parameters \
+      --db-cluster-parameter-group-name "$1" --source user \
+      --region "$3" --output json \
+      | jq '[.Parameters[] | select(.ParameterValue != null)]' > "${EXPORT_FILE}"
+  else
+    aws rds describe-db-parameters \
+      --db-parameter-group-name "$1" --source user \
+      --region "$3" --output json \
+      | jq '[.Parameters[] | select(.ParameterValue != null)]' > "${EXPORT_FILE}"
+  fi
+}
+
+fetch_target_valid_params() {
+  # $1 = group name, $2 = group type, $3 = region
+  if [[ "$2" == "cluster" ]]; then
+    aws rds describe-db-cluster-parameters \
+      --db-cluster-parameter-group-name "$1" \
+      --region "$3" --output json \
+      | jq '[.Parameters[]]' > "${TARGET_VALID_FILE}"
+  else
+    aws rds describe-db-parameters \
+      --db-parameter-group-name "$1" \
+      --region "$3" --output json \
+      | jq '[.Parameters[]]' > "${TARGET_VALID_FILE}"
+  fi
+}
+
+# ── Create Target Group ───────────────────────────────────
+
+create_target_group() {
+  # $1 = group name, $2 = family, $3 = description, $4 = group type, $5 = region
+  local group_name="$1" family="$2" description="$3"
+  local group_type="$4" region="$5"
+  local error_msg
+
+  if [[ "${group_type}" == "cluster" ]]; then
+    error_msg=$(
+      aws rds create-db-cluster-parameter-group \
+        --db-cluster-parameter-group-name "${group_name}" \
+        --db-parameter-group-family "${family}" \
+        --description "${description}" \
+        --region "${region}" \
+        --output json 2>&1
+    ) && {
+      log_info "Created cluster parameter group: ${group_name} (${region})"
+      return 0
+    }
+  else
+    error_msg=$(
+      aws rds create-db-parameter-group \
+        --db-parameter-group-name "${group_name}" \
+        --db-parameter-group-family "${family}" \
+        --description "${description}" \
+        --region "${region}" \
+        --output json 2>&1
+    ) && {
+      log_info "Created instance parameter group: ${group_name} (${region})"
+      return 0
+    }
+  fi
+
+  # Any failure — stop migration
+  log_error "Failed to create parameter group: ${group_name}"
+  log_error "Reason: $(echo "${error_msg}" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')"
+  exit 1
+}
+
+# ── Apply ─────────────────────────────────────────────────
+
+apply_single_param() {
+  # $1 = group name, $2 = param json array, $3 = group type, $4 = region
+  if [[ "$3" == "cluster" ]]; then
+    aws rds modify-db-cluster-parameter-group \
+      --db-cluster-parameter-group-name "$1" \
+      --parameters "$2" \
+      --region "$4" --output json > /dev/null 2>&1
+  else
+    aws rds modify-db-parameter-group \
+      --db-parameter-group-name "$1" \
+      --parameters "$2" \
+      --region "$4" --output json > /dev/null 2>&1
+  fi
+}
+
+get_error_msg() {
+  # $1 = group name, $2 = param json array, $3 = group type, $4 = region
+  if [[ "$3" == "cluster" ]]; then
+    aws rds modify-db-cluster-parameter-group \
+      --db-cluster-parameter-group-name "$1" \
+      --parameters "$2" \
+      --region "$4" 2>&1 || true
+  else
+    aws rds modify-db-parameter-group \
+      --db-parameter-group-name "$1" \
+      --parameters "$2" \
+      --region "$4" 2>&1 || true
+  fi | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//'
+}
+
+check_condition() {
+  # $1 = condition, $2 = param value
+  # Returns 0 (true) if condition is met
+  local condition="$1" value="$2"
+  case "${condition}" in
+    ne1) [[ "${value}" != "1" ]] && return 0 || return 1 ;;
+    *)   return 0 ;;
+  esac
+}
+
+resolve_and_retry() {
+  # Check if a known prerequisite exists for this parameter.
+  # If condition is met, apply prerequisite then retry with override value.
+  # Returns 0 if resolved successfully, 1 otherwise.
+  local param_name="$1" single="$2" group_name="$3"
+  local group_type="$4" region="$5"
+
+  for prereq in "${PARAM_PREREQUISITES[@]}"; do
+    local p condition prereq_name prereq_value prereq_method override_value
+    p=$(echo "${prereq}"              | cut -d: -f1)
+    condition=$(echo "${prereq}"      | cut -d: -f2)
+    prereq_name=$(echo "${prereq}"    | cut -d: -f3)
+    prereq_value=$(echo "${prereq}"   | cut -d: -f4)
+    prereq_method=$(echo "${prereq}"  | cut -d: -f5)
+    override_value=$(echo "${prereq}" | cut -d: -f6)
+
+    if [[ "${param_name}" != "${p}" ]]; then continue; fi
+
+    # Check if condition is met for this parameter value
+    local orig_value
+    orig_value=$(echo "${single}" | jq -r '.[0].ParameterValue')
+    if ! check_condition "${condition}" "${orig_value}"; then
+      return 1
+    fi
+
+    # Step 1: Apply prerequisite parameter
+    local prereq_json
+    prereq_json="[{
+      \"ParameterName\":  \"${prereq_name}\",
+      \"ParameterValue\": \"${prereq_value}\",
+      \"ApplyMethod\":    \"${prereq_method}\"
+    }]"
+
+    log_warn "  Prerequisite required: ${prereq_name}=${prereq_value}"
+
+    if ! apply_single_param "${group_name}" "${prereq_json}" "${group_type}" "${region}"; then
+      log_error "  ❌ Failed to apply prerequisite: ${prereq_name}=${prereq_value}"
+      return 1
+    fi
+    log_info "  ✅ Prerequisite applied: ${prereq_name}=${prereq_value}"
+
+    # Step 2: Build override value json
+    local apply_method final_single
+    apply_method=$(echo "${single}" | jq -r '.[0].ApplyMethod')
+    final_single="[{
+      \"ParameterName\":  \"${param_name}\",
+      \"ParameterValue\": \"${override_value}\",
+      \"ApplyMethod\":    \"${apply_method}\"
+    }]"
+    log_warn "  Value overridden: ${param_name} ${orig_value} → ${override_value}"
+    log_warn "  (Aurora MySQL supports 0 or 1 only, mapped to 0)"
+
+    # Step 3: Apply parameter with override value
+    if apply_single_param "${group_name}" "${final_single}" "${group_type}" "${region}"; then
+      log_info "  ✅ ${param_name}=${override_value}: applied (after prerequisite)"
+      TOTAL_APPLIED=$(( TOTAL_APPLIED + 1 ))
+      return 0
+    else
+      log_error "  ❌ ${param_name}: still failed after prerequisite"
+      return 1
+    fi
+  done
+
+  return 1
+}
+
+apply_batch_with_retry() {
+  # $1 = group name, $2 = batch json, $3 = group type, $4 = region
+  # $5 = batch num,  $6 = total batches
+  local group_name="$1" batch="$2" group_type="$3" region="$4"
+  local batch_num="$5" total_batches="$6"
+  local batch_count
+  batch_count=$(echo "${batch}" | jq 'length')
+
+  # Try applying the whole batch first
+  if apply_single_param "${group_name}" "${batch}" "${group_type}" "${region}"; then
+    log_info "✅ Batch ${batch_num}/${total_batches}: ${batch_count} params applied"
+    TOTAL_APPLIED=$(( TOTAL_APPLIED + batch_count ))
+    return
+  fi
+
+  # Batch failed — retry each parameter individually
+  log_warn "Batch ${batch_num}/${total_batches} failed — retrying individually..."
+  for (( j=0; j<batch_count; j++ )); do
+    local single param_name error_msg
+    single=$(echo "${batch}" | jq "[.[${j}]]")
+    param_name=$(echo "${single}" | jq -r '.[0].ParameterName')
+
+    if apply_single_param "${group_name}" "${single}" "${group_type}" "${region}"; then
+      log_info "  ✅ ${param_name}: applied"
+      TOTAL_APPLIED=$(( TOTAL_APPLIED + 1 ))
+    else
+      # Check if a prerequisite can resolve this failure
+      if resolve_and_retry \
+          "${param_name}" "${single}" \
+          "${group_name}" "${group_type}" "${region}"; then
+        continue
+      fi
+
+      # No prerequisite or prerequisite failed — record error
+      error_msg=$(get_error_msg "${group_name}" "${single}" "${group_type}" "${region}")
+      log_error "  ❌ ${param_name}: failed"
+      log_warn  "     Reason: ${error_msg}"
+
+      jq --argjson new \
+        "$(echo "${single}" | jq \
+          --arg reason "${error_msg}" \
+          '.[0] + {FailReason: $reason}')" \
+        '. + [$new]' "${FAILED_TMP}" > "${FAILED_TMP}.tmp" \
+        && mv "${FAILED_TMP}.tmp" "${FAILED_TMP}"
+    fi
+  done
+}
+
+# ── Filter Parameters ─────────────────────────────────────
+# APPLICABLE   : found in target engine AND IsModifiable = true
+# SKIPPED      : found in target engine BUT IsModifiable = false
+# INCOMPATIBLE : not found in target engine at all
+
+filter_params() {
+  jq --slurpfile target "${TARGET_VALID_FILE}" '
+    . as $src |
+    ($target[0] | map({(.ParameterName): .}) | add) as $tmap |
+    $src | map(
+      select(
+        .ParameterValue != null and
+        $tmap[.ParameterName] != null and
+        $tmap[.ParameterName].IsModifiable == true
+      ) | {
+        ParameterName,
+        ParameterValue,
+        ApplyMethod: ($tmap[.ParameterName].ApplyMethod // "pending-reboot")
+      }
+    )
+  ' "${EXPORT_FILE}" > "${APPLICABLE_FILE}"
+
+  jq --slurpfile target "${TARGET_VALID_FILE}" '
+    . as $src |
+    ($target[0] | map({(.ParameterName): .}) | add) as $tmap |
+    $src | map(
+      select(
+        .ParameterValue != null and
+        $tmap[.ParameterName] != null and
+        $tmap[.ParameterName].IsModifiable == false
+      ) | {
+        ParameterName,
+        ParameterValue,
+        SkipReason: "Not modifiable in target engine"
+      }
+    )
+  ' "${EXPORT_FILE}" > "${SKIPPED_FILE}"
+
+  jq --slurpfile target "${TARGET_VALID_FILE}" '
+    . as $src |
+    ($target[0] | map({(.ParameterName): .}) | add) as $tmap |
+    $src | map(
+      select(
+        .ParameterValue != null and
+        $tmap[.ParameterName] == null
+      ) | {
+        ParameterName,
+        ParameterValue,
+        SkipReason: "Not found in target engine"
+      }
+    )
+  ' "${EXPORT_FILE}" > "${INCOMPATIBLE_FILE}"
+}
+
+# ── Report ────────────────────────────────────────────────
+
+generate_report() {
+  cp "${FAILED_TMP}" "${FAILED_FILE}"
+
+  cat > "${REPORT_FILE}" << EOF
+============================================================
+  PARAMETER GROUP MIGRATION REPORT
+  Date    : $(date)
+  DryRun  : ${DRY_RUN}
+============================================================
+  Source  : ${SOURCE_PARAM_GROUP} [${SOURCE_FAMILY} | ${SOURCE_TYPE} | ${SOURCE_REGION}]
+  Target  : ${TARGET_PARAM_GROUP} [${TARGET_FAMILY} | ${TARGET_TYPE} | ${TARGET_REGION}]
+------------------------------------------------------------
+  Total Exported  : $(jq 'length' "${EXPORT_FILE}")
+  Applied         : ${TOTAL_APPLIED}
+  Skipped         : $(jq 'length' "${SKIPPED_FILE}")
+  Incompatible    : $(jq 'length' "${INCOMPATIBLE_FILE}")
+  Failed          : $(jq 'length' "${FAILED_FILE}")
+============================================================
+
+=== APPLIED ===
+$(jq -r '["Name","Value","ApplyMethod"],
+         (.[] | [.ParameterName,.ParameterValue,.ApplyMethod]) | @tsv' \
+  "${APPLICABLE_FILE}" | column -t)
+
+=== SKIPPED (Not Modifiable in Target Engine) ===
+$(jq -r '["Name","Value","Reason"],
+         (.[] | [.ParameterName,.ParameterValue,.SkipReason]) | @tsv' \
+  "${SKIPPED_FILE}" | column -t)
+
+=== INCOMPATIBLE (Not Found in Target Engine) ===
+$(jq -r '["Name","Value","Reason"],
+         (.[] | [.ParameterName,.ParameterValue,.SkipReason]) | @tsv' \
+  "${INCOMPATIBLE_FILE}" | column -t)
+
+=== FAILED (API Rejected — Review Required) ===
+$(jq -r '.[] | "  Name   : \(.ParameterName)\n  Value  : \(.ParameterValue)\n  Reason : \(.FailReason)\n"' \
+  "${FAILED_FILE}")
+EOF
+  cat "${REPORT_FILE}"
+}
+
+# ── Main ──────────────────────────────────────────────────
+
+main() {
+  log_section "DB Parameter Group Migration Tool"
+  [[ "${DRY_RUN}" == "true" ]] && log_warn "DRY RUN — no changes will be applied"
+
+  log_section "Step 1: Detect Parameter Group Types"
+  SOURCE_TYPE=$(detect_group_type "${SOURCE_PARAM_GROUP}" "${SOURCE_REGION}")
+  [[ "${SOURCE_TYPE}" == "not_found" ]] && \
+    log_error "Source group '${SOURCE_PARAM_GROUP}' not found in ${SOURCE_REGION}" && exit 1
+
+  SOURCE_FAMILY=$(get_source_family "${SOURCE_PARAM_GROUP}" "${SOURCE_TYPE}" "${SOURCE_REGION}")
+  TARGET_TYPE=$(target_group_type_from_family "${TARGET_FAMILY}")
+
+  log_info "Source : ${SOURCE_PARAM_GROUP} | ${SOURCE_TYPE} | ${SOURCE_FAMILY} | ${SOURCE_REGION}"
+  log_info "Target : ${TARGET_PARAM_GROUP} | ${TARGET_TYPE} | ${TARGET_FAMILY} | ${TARGET_REGION}"
+
+  [[ "${SOURCE_REGION}" != "${TARGET_REGION}" ]] && \
+    log_warn "Cross-region copy: ${SOURCE_REGION} → ${TARGET_REGION}"
+
+  log_section "Step 2: Export Source Parameters"
+  export_params "${SOURCE_PARAM_GROUP}" "${SOURCE_TYPE}" "${SOURCE_REGION}"
+  log_info "Exported $(jq 'length' "${EXPORT_FILE}") modified parameters"
+  jq -r '["Name","Value","ApplyType"],
+          (.[] | [.ParameterName,.ParameterValue,.ApplyType]) | @tsv' \
+    "${EXPORT_FILE}" | column -t
+
+  log_section "Step 3: Create Target Parameter Group"
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    create_target_group \
+      "${TARGET_PARAM_GROUP}" "${TARGET_FAMILY}" \
+      "Migrated from: ${SOURCE_PARAM_GROUP} (${SOURCE_REGION})" \
+      "${TARGET_TYPE}" "${TARGET_REGION}"
+  else
+    log_warn "[DRY RUN] Would create ${TARGET_TYPE} group: ${TARGET_PARAM_GROUP} (${TARGET_FAMILY}) in ${TARGET_REGION}"
+  fi
+
+  log_section "Step 4: Fetch Target Valid Parameters"
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    fetch_target_valid_params "${TARGET_PARAM_GROUP}" "${TARGET_TYPE}" "${TARGET_REGION}"
+  else
+    log_warn "[DRY RUN] Using source group for valid parameter lookup"
+    fetch_target_valid_params "${SOURCE_PARAM_GROUP}" "${SOURCE_TYPE}" "${SOURCE_REGION}"
+  fi
+  log_info "Found $(jq 'length' "${TARGET_VALID_FILE}") valid parameters in target"
+
+  log_section "Step 5: Filter Parameters"
+  filter_params
+
+  APPLICABLE_COUNT=$(jq 'length' "${APPLICABLE_FILE}")
+  echo "--------------------------------------------"
+  echo " Total Exported : $(jq 'length' "${EXPORT_FILE}")"
+  echo " Applicable     : ${APPLICABLE_COUNT}"
+  echo " Skipped        : $(jq 'length' "${SKIPPED_FILE}")"
+  echo " Incompatible   : $(jq 'length' "${INCOMPATIBLE_FILE}")"
+  echo "--------------------------------------------"
+
+  log_section "Step 6: Apply Parameters"
+  TOTAL_APPLIED=0
+
+  if [[ "${APPLICABLE_COUNT}" -gt 0 ]]; then
+    TOTAL_BATCHES=$(( (APPLICABLE_COUNT + BATCH_SIZE - 1) / BATCH_SIZE ))
+    for (( i=0; i<APPLICABLE_COUNT; i+=BATCH_SIZE )); do
+      BATCH_NUM=$(( i / BATCH_SIZE + 1 ))
+      BATCH=$(jq ".[${i}:$(( i + BATCH_SIZE ))]" "${APPLICABLE_FILE}")
+
+      if [[ "${DRY_RUN}" == "false" ]]; then
+        apply_batch_with_retry \
+          "${TARGET_PARAM_GROUP}" "${BATCH}" \
+          "${TARGET_TYPE}" "${TARGET_REGION}" \
+          "${BATCH_NUM}" "${TOTAL_BATCHES}"
+        sleep 1
+      else
+        BATCH_COUNT=$(echo "${BATCH}" | jq 'length')
+        log_warn "[DRY RUN] Batch ${BATCH_NUM}/${TOTAL_BATCHES}: ${BATCH_COUNT} params"
+        TOTAL_APPLIED=$(( TOTAL_APPLIED + BATCH_COUNT ))
+      fi
+    done
+  fi
+
+  FAILED_COUNT=$(jq 'length' "${FAILED_TMP}")
+  log_info "Applied  : ${TOTAL_APPLIED}/${APPLICABLE_COUNT} parameters"
+  [[ "${FAILED_COUNT}" -gt 0 ]] && \
+    log_warn "Failed   : ${FAILED_COUNT} parameters — check ${FAILED_FILE} for details"
+
+  log_section "Step 7: Generate Report"
+  generate_report
+  log_info "Output: ${WORK_DIR}/"
+}
+
+main


### PR DESCRIPTION
PR 1: Fix binlog script (issue #84)

Issue #: #84

Description of changes: Fix incomplete binary log download by excluding the last (active) binary log file. The master may still be writing to the last binary log, resulting in incomplete data when downloaded. Changed mysql_binlog_filename from a string to a bash array and modified the loop to skip the last element. Also added a README.md for the rds-binlog-to-s3 tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

PR 2: Add parameter-migrate tool

Issue #: N/A (new tool)

Description of changes: Add parameter-migrate — a bash script to automate RDS/Aurora parameter group migration across engine versions, engine types (RDS ↔ Aurora), and AWS regions using the AWS CLI. Features include automatic source/target type detection, compatibility filtering (applicable/skipped/incompatible), batch apply with individual retry on failure, parameter prerequisite handling (e.g., innodb_flush_log_at_trx_commit in Aurora MySQL 3), cross-region support, dry run mode, and a full migration report. Requires only AWS CLI and jq.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

