### PR TITLE
Fix incomplete binlog download by excluding active log file (#84)

### DIFF
--- a/mysql/rds-binlog-to-s3/README.md
+++ b/mysql/rds-binlog-to-s3/README.md
@@ -63,7 +63,7 @@ crontab -e
 ```
 RDS MySQL Instance
        │
-       │  SHOW MASTER LOGS
+       │  SHOW BINARY LOGS
        ▼
   List binary log files
   (exclude last — may be incomplete)

--- a/mysql/rds-binlog-to-s3/README.md
+++ b/mysql/rds-binlog-to-s3/README.md
@@ -1,0 +1,89 @@
+# RDS MySQL Binary Log Backup to S3
+
+Download binary log files from an Amazon RDS MySQL instance and upload them to Amazon S3 on a scheduled basis.
+
+## Overview
+
+This script automates the process of:
+
+1. Connecting to an RDS MySQL instance and listing available binary logs
+2. Downloading each binary log using `mysqlbinlog --read-from-remote-server`
+3. Uploading the downloaded files to an S3 bucket using `aws s3 sync`
+4. Cleaning up local binlog files older than 1 day
+
+Binary log backups are useful for point-in-time recovery beyond the RDS automated backup retention period, compliance and audit requirements, and disaster recovery to a different region or account.
+
+> **Note:** The script excludes the last (most recent) binary log from the download because it may still be actively written to by the MySQL server, which would result in an incomplete file. See [issue #84](https://github.com/awslabs/rds-support-tools/issues/84).
+
+For more details, see [How can I schedule uploads of Amazon RDS MySQL binary logs to Amazon S3?](https://repost.aws/knowledge-center/rds-mysql-schedule-binlog-uploads)
+
+## Prerequisites
+
+- An EC2 instance (or similar host) with network access to the RDS MySQL instance
+- MySQL client (`mysql` and `mysqlbinlog` commands)
+- AWS CLI configured with permissions to write to the target S3 bucket (`aws configure`)
+- An RDS MySQL user with `REPLICATION SLAVE` privilege
+
+## Setup
+
+1. Edit the script variables to match your environment:
+
+```bash
+Backup_dir=/home/ec2-user/backup/binlog/$(date "+%Y-%m-%d")
+Bucket='rds-binlogs'                                          # S3 bucket name
+RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'          # RDS endpoint
+master='admin'                                                 # MySQL username
+export MYSQL_PWD='your_password'                               # MySQL password
+```
+
+> **Security:** Avoid hardcoding passwords in the script. Consider using AWS Secrets Manager, a `.my.cnf` file with restricted permissions, or environment variables instead.
+
+2. Make the script executable:
+
+```bash
+chmod +x rds-binlog-to-s3.sh
+```
+
+3. Test manually:
+
+```bash
+./rds-binlog-to-s3.sh
+```
+
+4. Schedule with cron (e.g., every hour):
+
+```bash
+crontab -e
+# Add:
+0 * * * * /path/to/rds-binlog-to-s3.sh >> /var/log/binlog-backup.log 2>&1
+```
+
+## How It Works
+
+```
+RDS MySQL Instance
+       │
+       │  SHOW MASTER LOGS
+       ▼
+  List binary log files
+  (exclude last — may be incomplete)
+       │
+       │  mysqlbinlog --read-from-remote-server
+       ▼
+  Local backup directory
+  /home/ec2-user/backup/binlog/YYYY-MM-DD/
+       │
+       │  aws s3 sync
+       ▼
+  s3://rds-binlogs/binlog/
+       │
+       │  find -mtime +1 -exec rm
+       ▼
+  Clean up local files older than 1 day
+```
+
+## Additional Resources
+
+- [Working with MySQL Binary Logs on RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.MySQL.BinaryFormat.html)
+- [mysqlbinlog — Utility for Processing Binary Log Files](https://dev.mysql.com/doc/refman/8.0/en/mysqlbinlog.html)
+- [AWS CLI S3 sync](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html)

--- a/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
+++ b/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
@@ -25,10 +25,12 @@ RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'
 dbuser='admin'
 export MYSQL_PWD='test1234'
 
-# Converting to array — the last binary log may still be actively written
-# to by the master, so we exclude it to avoid downloading incomplete data.
+# "SHOW MASTER LOGS" was removed in MySQL 8.4. Use "SHOW BINARY LOGS" which
+# works on MySQL 5.7+ and is the only option for 8.4+.
+# The last binary log may still be actively written to by the master,
+# so we exclude it to avoid downloading incomplete data.
 # See: https://github.com/awslabs/rds-support-tools/issues/84
-mysql_binlog_filename=($(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}'))
+mysql_binlog_filename=($(mysql -u $master -h $RDS -e "SHOW BINARY LOGS"|grep "mysql-bin"|awk '{print $1}'))
 
 for file in ${mysql_binlog_filename[@]::${#mysql_binlog_filename[@]}-1}
 do

--- a/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
+++ b/mysql/rds-binlog-to-s3/rds-binlog-to-s3.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 #
+#  Copyright 2016 Amazon.com, Inc. or its affiliates.
+#  All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#      http://aws.amazon.com/apache2.0/
+#
+#  or in the "license" file accompanying this file.
+#  This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#  CONDITIONS OF ANY KIND, either express or implied. See the License
+#  for the specific language governing permissions and limitations
+#  under the License.
+#
 #Script to download RDS MySQL binlog files using mysqlbinlog command and the AWS CLI tools to upload them to S3.
 #Install AWS CLI tools see: "http://docs.aws.amazon.com/cli/latest/userguide/installing.html"
 #Config your AWS config File (aws configure)
@@ -10,9 +25,12 @@ RDS='mysql57.xxxxxxxxxx.us-west-2.rds.amazonaws.com'
 master='admin'
 export MYSQL_PWD='test1234'
 
-mysql_binlog_filename=$(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}')
+# Converting to array — the last binary log may still be actively written
+# to by the master, so we exclude it to avoid downloading incomplete data.
+# See: https://github.com/awslabs/rds-support-tools/issues/84
+mysql_binlog_filename=($(mysql -u $master -h $RDS -e "show master logs"|grep "mysql-bin"|awk '{print $1}'))
 
-for file in $mysql_binlog_filename
+for file in ${mysql_binlog_filename[@]::${#mysql_binlog_filename[@]}-1}
 do
         if ! test -d $Backup_dir
         then


### PR DESCRIPTION
Issue #: #84
Description: Fix incomplete binary log download by excluding the last (active) binary log file from the download list. The master may still be writing to it, resulting in incomplete data. Also added license header and README.md.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
