### PR TITLE
Modify(postgres): Update README to clarify RDS/Aurora PostgreSQL scope

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -41,9 +41,9 @@
 * [RDS Proxy](https://aws.amazon.com/rds/proxy/)
 
 ## Aurora/RDS PostgreSQL Major Version Upgrade Pre-check Tool:
-* [Shell Script Version](https://github.com/nickyhsu-aws/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/shell)
-* [SQL Version](https://github.com/nickyhsu-aws/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/sql)
-* [PL/PGSQL Version](https://github.com/nickyhsu-aws/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql)
+* [Shell Script Version](https://github.com/awslabs/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/shell)
+* [SQL Version](https://github.com/awslabs/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/sql)
+* [PL/PGSQL Version](https://github.com/awslabs/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql)
 
 ## Other scripts:
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
@@ -1,6 +1,6 @@
 # Aurora/RDS PostgreSQL Major Version Upgrade Precheck Tool (PL/PGSQL)
 
-Run this tool before performing a Major Version Upgrade on Aurora PostgreSQL or RDS PostgreSQL to detect common issues that may cause the upgrade to fail.
+Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 
 Supported target versions: PostgreSQL 11 – 17
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
@@ -1,4 +1,4 @@
-# Aurora/RDS PostgreSQL Major Version Upgrade Precheck Tool (PL/PGSQL)
+# RDS/Aurora PostgreSQL Major Version Upgrade Precheck Tool (PL/PGSQL)
 
 Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Validates PostgreSQL databases before a major version upgrade. Identifies configuration issues, compatibility blockers, and Blue/Green deployment requirements.
+Validates RDS/Aurora PostgreSQL databases before a major version upgrade. Identifies configuration issues, compatibility blockers, and Blue/Green deployment requirements.
 
 ## Prerequisites
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
@@ -1,4 +1,4 @@
-# PostgreSQL Major Version Upgrade (MVU) Pre-Check Script
+# RDS/Aurora PostgreSQL Major Version Upgrade (MVU) Pre-Check Script
 
 ## Overview
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
@@ -136,4 +136,4 @@ export BLUE_GREEN_MODE="true"
 
 ## Batch Execution
 
-Use `wrapper.sh` to run checks against multiple databases from a CSV file. See `WRAPPER-README.md`.
+Use `wrapper.sh` to run checks against multiple RDS/Aurora PostgreSQL Instances/Clusters from a CSV file. See `WRAPPER-README.md`.

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/README.md
@@ -1,4 +1,4 @@
-# RDS/Aurora PostgreSQL Major Version Upgrade (MVU) Pre-Check Script
+# RDS/Aurora PostgreSQL Major Version Upgrade Precheck Tool
 
 ## Overview
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/WRAPPER-README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/WRAPPER-README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`wrapper.sh` runs pre-upgrade checks against multiple PostgreSQL databases using a CSV file. It calls `pg-major-version-upgrade-precheck.sh` for each entry and produces a summary of results.
+`wrapper.sh` runs pre-upgrade checks against multiple RDS/Aurora PostgreSQL Instances/Clusters using a CSV file. It calls `pg-major-version-upgrade-precheck.sh` for each entry and produces a summary of results.
 
 ## Prerequisites
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
@@ -1,4 +1,4 @@
-# Aurora/RDS PostgreSQL Major Version Upgrade Precheck Tool (SQL)
+# RDS/Aurora PostgreSQL Major Version Upgrade Precheck Tool (SQL)
 
 Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
@@ -1,6 +1,6 @@
 # Aurora/RDS PostgreSQL Major Version Upgrade Precheck Tool (SQL)
 
-Run this tool before performing a Major Version Upgrade on Aurora PostgreSQL or RDS PostgreSQL to detect common issues that may cause the upgrade to fail.
+Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 
 Supported target versions: PostgreSQL 11 – 17
 


### PR DESCRIPTION
*Description of changes:*

Minor documentation update. Changed references from "PostgreSQL" to "RDS/Aurora PostgreSQL" in README files to clarify that this tool is designed for AWS managed PostgreSQL services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.