### PR TITLE
feat(precheck): Add target version 18 checks and fix bugs

### DIFF
--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/README.md
@@ -2,7 +2,7 @@
 
 Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 
-Supported target versions: PostgreSQL 11 – 17
+Supported target versions: PostgreSQL 11 – 18
 
 > **Note:** These SQL scripts must be executed against each database individually. If you need automated execution across all databases in a cluster, use the [shell script version](https://github.com/awslabs/rds-support-tools/tree/main/postgres/diag/pg-major-version-upgrade-precheck-tool/shell) which iterates all user databases automatically.
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/pg-major-version-upgrade-precheck-plpgsql.sql
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/pg-major-version-upgrade-precheck-plpgsql.sql
@@ -17,7 +17,7 @@
 -- ============================================
 -- Aurora/RDS PostgreSQL Major Version Upgrade Precheck
 -- PL/pgSQL Version
--- Supports: Target Major Version 11-17
+-- Supports: Target Major Version 11-18
 --
 -- Each check is either:
 --   [global]       - Run once against the postgres database
@@ -96,9 +96,12 @@ DECLARE
     v_need_slot_check   boolean;
     v_target_ge_11      boolean;
     v_target_ge_14      boolean;
+    v_target_ge_18      boolean;
     v_need_aclitem_check boolean;
     v_source_le_11      boolean;
     v_source_le_13      boolean;
+    v_source_ge_17      boolean;
+    v_is_aurora         boolean;
 BEGIN
     -- Prevent runaway queries from holding catalog locks too long
     SET LOCAL statement_timeout = 600000;   -- 10 minutes
@@ -134,13 +137,21 @@ BEGIN
     v_need_slot_check    := (v_source_major < 17);
     v_target_ge_11       := (p_target_version >= 11);
     v_target_ge_14       := (p_target_version >= 14);
+    v_target_ge_18       := (p_target_version >= 18);
     v_need_aclitem_check := (v_source_major <= 15 AND p_target_version >= 16);
     v_source_le_11       := (v_source_major <= 11);
     v_source_le_13       := (v_source_major <= 13);
+    v_source_ge_17       := (v_source_major >= 17);
 
-    -- Validate target_version is within supported range (11-17)
-    IF p_target_version < 11 OR p_target_version > 17 THEN
-        RAISE EXCEPTION 'ERROR: Target version must be between 11 and 17. Got: %', p_target_version;
+    -- Validate target_version is within supported range (11-18)
+    IF p_target_version < 11 OR p_target_version > 18 THEN
+        RAISE EXCEPTION 'ERROR: Target version must be between 11 and 18. Got: %', p_target_version;
+    END IF;
+
+    -- Aurora PostgreSQL does not yet support target version 18
+    v_is_aurora := (to_regproc('aurora_version') IS NOT NULL);
+    IF v_is_aurora AND p_target_version >= 18 THEN
+        RAISE EXCEPTION 'ERROR: Aurora PostgreSQL does not support target version 18 yet. Supported: 11-17.';
     END IF;
 
     -- Version sanity check
@@ -503,7 +514,7 @@ BEGIN
         END IF;
     ELSE
         v_status := '- SKIP';
-        v_msg := 'Skipped (APG 17+ supports logical slot migration).';
+        v_msg := 'Skipped (PG 17+ supports logical slot migration).';
     END IF;
     RAISE NOTICE '%: %', v_status, v_msg;
     IF v_detail IS NOT NULL AND v_detail != '' THEN
@@ -1963,6 +1974,369 @@ BEGIN
         RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
     END IF;
     check_id := '46'; check_scope := 'per-database'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 47. check_old_cluster_for_valid_slots - invalid slots [global]
+    -- (source >= 17; logical slot migration requires valid slots)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 47. check_old_cluster_for_valid_slots - invalid slots [global] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_source_ge_17 THEN
+        SELECT count(*) INTO v_count
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND invalidation_reason IS NOT NULL;
+        IF v_count > 0 THEN
+            v_status := '❌ FAILED';
+            v_msg := v_count || ' invalidated logical slot(s). Drop them before upgrade.';
+            SELECT string_agg(slot_name || ' (reason: ' || invalidation_reason || ', db: ' || COALESCE(database, 'N/A') || ')', E'\n    ')
+            INTO v_detail
+            FROM pg_catalog.pg_replication_slots
+            WHERE slot_type = 'logical'
+              AND temporary = false
+              AND invalidation_reason IS NOT NULL;
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'No invalidated logical slots.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (source version < 17; logical slot migration not applicable).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '47'; check_scope := 'global'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global]
+    -- (source >= 17; inactive slots must have consumed all WAL before shutdown)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_source_ge_17 THEN
+        SELECT count(*) INTO v_count
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND active = false
+          AND invalidation_reason IS NULL
+          AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+        IF v_count > 0 THEN
+            v_status := '❌ FAILED';
+            v_msg := v_count || ' inactive logical slot(s) with unconsumed WAL. After shutdown, pg_upgrade will reject these. Either consume pending WAL or drop the slot(s).';
+            SELECT string_agg(slot_name || ' (db: ' || COALESCE(database, 'N/A') || ', lag: ' || pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) || ')', E'\n    ')
+            INTO v_detail
+            FROM pg_catalog.pg_replication_slots
+            WHERE slot_type = 'logical'
+              AND temporary = false
+              AND active = false
+              AND invalidation_reason IS NULL
+              AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'No inactive slots with unconsumed WAL.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (source version < 17).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '47b'; check_scope := 'global'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 47c. check_old_cluster_for_valid_slots - active slots with WAL lag [global]
+    -- (source >= 17; WARNING only)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 47c. check_old_cluster_for_valid_slots - active slots with WAL lag [global] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_source_ge_17 THEN
+        SELECT count(*) INTO v_count
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND active = true
+          AND invalidation_reason IS NULL
+          AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+        IF v_count > 0 THEN
+            v_status := '⚠️ WARNING';
+            v_msg := v_count || ' active logical slot(s) with WAL lag. Ensure consumers are caught up before stopping the instance for upgrade.';
+            SELECT string_agg(slot_name || ' (db: ' || COALESCE(database, 'N/A') || ', lag: ' || pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) || ')', E'\n    ')
+            INTO v_detail
+            FROM pg_catalog.pg_replication_slots
+            WHERE slot_type = 'logical'
+              AND temporary = false
+              AND active = true
+              AND invalidation_reason IS NULL
+              AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'No active slots with concerning lag.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (source version < 17).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '47c'; check_scope := 'global'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 48. check_old_cluster_subscription_state [per-database]
+    -- (source >= 17; subscription relations must be in 'i' or 'r' state,
+    --  and each subscription must have a replication origin)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 48. check_old_cluster_subscription_state [per-database] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_source_ge_17 THEN
+        SELECT count(*) INTO v_count
+        FROM (
+            -- Subscriptions missing replication origin
+            SELECT s.subname AS item
+            FROM pg_catalog.pg_subscription s
+            LEFT JOIN pg_catalog.pg_replication_origin o
+                   ON o.roname = 'pg_' || s.oid::text
+            WHERE o.roname IS NULL
+            UNION ALL
+            -- Subscription relations not in i/r state
+            SELECT s.subname || '.' || c.relname
+            FROM pg_catalog.pg_subscription_rel r
+            JOIN pg_catalog.pg_subscription s ON r.srsubid = s.oid
+            JOIN pg_catalog.pg_class c        ON r.srrelid = c.oid
+            WHERE r.srsubstate NOT IN ('i', 'r')
+        ) sub;
+        IF v_count > 0 THEN
+            v_status := '❌ FAILED';
+            v_msg := v_count || ' subscription issue(s) found. Fix before upgrade.';
+            SELECT string_agg(item, E'\n    ')
+            INTO v_detail
+            FROM (
+                SELECT s.subname || ': missing replication origin' AS item
+                FROM pg_catalog.pg_subscription s
+                LEFT JOIN pg_catalog.pg_replication_origin o
+                       ON o.roname = 'pg_' || s.oid::text
+                WHERE o.roname IS NULL
+                UNION ALL
+                SELECT s.subname || '.' || c.relname || ': state=' || r.srsubstate::text
+                FROM pg_catalog.pg_subscription_rel r
+                JOIN pg_catalog.pg_subscription s ON r.srsubid = s.oid
+                JOIN pg_catalog.pg_class c        ON r.srrelid = c.oid
+                WHERE r.srsubstate NOT IN ('i', 'r')
+            ) sub;
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'All subscriptions have valid origins and relation states.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (source version < 17).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '48'; check_scope := 'per-database'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 49. check_for_isn_and_int8_passing_mismatch [per-database]
+    -- (All versions; contrib/isn relies on int8 pass-by-value behavior.
+    --  On RDS the old/new clusters normally have the same setting,
+    --  but we flag if contrib/isn is installed as informational.)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 49. check_for_isn_and_int8_passing_mismatch [per-database] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSE
+    SELECT count(*) INTO v_count
+    FROM pg_catalog.pg_proc p
+    WHERE p.probin = '$libdir/isn';
+    IF v_count > 0 THEN
+        v_status := '⚠️ WARNING';
+        v_msg := v_count || ' contrib/isn function(s) found. If old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. On RDS this is normally consistent, but verify before upgrading.';
+        SELECT string_agg(n.nspname || '.' || p.proname, E'\n    ' ORDER BY n.nspname, p.proname)
+        INTO v_detail
+        FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+        WHERE p.probin = '$libdir/isn';
+    ELSE
+        v_status := '✓ PASSED';
+        v_msg := 'No contrib/isn functions found.';
+    END IF;
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '49'; check_scope := 'per-database'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 50. check_for_not_null_inheritance [per-database]
+    -- (target >= 18; child tables must not omit NOT NULL constraints
+    --  that parents have)
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 50. check_for_not_null_inheritance [per-database] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_target_ge_18 THEN
+        SELECT count(*) INTO v_count
+        FROM pg_catalog.pg_inherits i
+        JOIN pg_catalog.pg_attribute ac ON ac.attrelid = i.inhrelid
+        JOIN pg_catalog.pg_attribute ap ON ap.attrelid = i.inhparent AND ap.attname = ac.attname
+        WHERE ap.attnum > 0
+          AND ap.attnotnull
+          AND NOT ac.attnotnull;
+        IF v_count > 0 THEN
+            v_status := '❌ FAILED';
+            v_msg := v_count || ' NOT NULL inheritance inconsistency(ies). Child columns missing NOT NULL that parent has. Fix with ALTER TABLE child ALTER COLUMN col SET NOT NULL.';
+            SELECT string_agg(nc.nspname || '.' || cc.relname || '.' || ac.attname, E'\n    ')
+            INTO v_detail
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_attribute ac ON ac.attrelid = i.inhrelid
+            JOIN pg_catalog.pg_attribute ap ON ap.attrelid = i.inhparent AND ap.attname = ac.attname
+            JOIN pg_catalog.pg_class cc ON cc.oid = ac.attrelid
+            JOIN pg_catalog.pg_namespace nc ON nc.oid = cc.relnamespace
+            WHERE ap.attnum > 0
+              AND ap.attnotnull
+              AND NOT ac.attnotnull;
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'No NOT NULL inheritance inconsistencies.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (target < 18).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '50'; check_scope := 'per-database'; status := v_status; message := v_msg; detail := v_detail;
+    RETURN NEXT;
+    RAISE NOTICE '';
+
+    -- --------------------------------------------
+    -- Check 51. check_for_unicode_update [per-database]
+    -- (source >= 17 AND target >= 18; WARNING only)
+    -- Surfaces indexes/partitions/constraints/matviews that use
+    -- Unicode-dependent functions which may produce different results
+    -- if the Unicode version changed between old and new clusters.
+    -- --------------------------------------------
+    v_detail := '';
+    RAISE NOTICE '=== 51. check_for_unicode_update [per-database] ===';
+    IF v_is_aurora THEN
+        v_status := '- SKIP';
+        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
+    ELSIF v_source_ge_17 AND v_target_ge_18 THEN
+        SELECT count(*) INTO v_count
+        FROM (
+            SELECT ix.indexrelid AS reloid
+            FROM pg_catalog.pg_index ix
+            WHERE EXISTS (
+                SELECT 1 FROM pg_catalog.pg_proc f
+                JOIN pg_catalog.pg_namespace fn ON f.pronamespace = fn.oid
+                WHERE fn.nspname = 'pg_catalog'
+                  AND (f.proname IN ('normalize','unicode_assigned','unicode_version','is_normalized',
+                                     'lower','upper','initcap','casefold')
+                       OR f.proname LIKE 'regexp_%')
+                  AND (ix.indexprs::text LIKE '%:funcid ' || f.oid || ' %'
+                       OR ix.indpred::text LIKE '%:funcid ' || f.oid || ' %')
+            )
+            UNION ALL
+            SELECT pt.partrelid
+            FROM pg_catalog.pg_partitioned_table pt
+            WHERE EXISTS (
+                SELECT 1 FROM pg_catalog.pg_proc f
+                JOIN pg_catalog.pg_namespace fn ON f.pronamespace = fn.oid
+                WHERE fn.nspname = 'pg_catalog'
+                  AND (f.proname IN ('normalize','unicode_assigned','unicode_version','is_normalized',
+                                     'lower','upper','initcap','casefold')
+                       OR f.proname LIKE 'regexp_%')
+                  AND pt.partexprs::text LIKE '%:funcid ' || f.oid || ' %'
+            )
+            UNION ALL
+            SELECT co.conrelid
+            FROM pg_catalog.pg_constraint co
+            WHERE co.conbin IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM pg_catalog.pg_proc f
+                  JOIN pg_catalog.pg_namespace fn ON f.pronamespace = fn.oid
+                  WHERE fn.nspname = 'pg_catalog'
+                    AND (f.proname IN ('normalize','unicode_assigned','unicode_version','is_normalized',
+                                       'lower','upper','initcap','casefold')
+                         OR f.proname LIKE 'regexp_%')
+                    AND co.conbin::text LIKE '%:funcid ' || f.oid || ' %'
+              )
+        ) affected;
+        IF v_count > 0 THEN
+            v_status := '⚠️ WARNING';
+            v_msg := v_count || ' object(s) reference Unicode-dependent functions. If the Unicode version differs between old and new clusters, consider REINDEX or rebuilding affected objects after upgrade.';
+            SELECT string_agg(n.nspname || '.' || c.relname, E'\n    ')
+            INTO v_detail
+            FROM (
+                SELECT ix.indexrelid AS reloid
+                FROM pg_catalog.pg_index ix
+                WHERE EXISTS (
+                    SELECT 1 FROM pg_catalog.pg_proc f
+                    JOIN pg_catalog.pg_namespace fn ON f.pronamespace = fn.oid
+                    WHERE fn.nspname = 'pg_catalog'
+                      AND (f.proname IN ('normalize','unicode_assigned','unicode_version','is_normalized',
+                                         'lower','upper','initcap','casefold')
+                           OR f.proname LIKE 'regexp_%')
+                      AND (ix.indexprs::text LIKE '%:funcid ' || f.oid || ' %'
+                           OR ix.indpred::text LIKE '%:funcid ' || f.oid || ' %')
+                )
+            ) sub
+            JOIN pg_catalog.pg_class c ON c.oid = sub.reloid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            LIMIT 50;
+        ELSE
+            v_status := '✓ PASSED';
+            v_msg := 'No Unicode-dependent objects found.';
+        END IF;
+    ELSE
+        v_status := '- SKIP';
+        v_msg := 'Skipped (only meaningful when source >= 17 and target >= 18).';
+    END IF;
+    RAISE NOTICE '%: %', v_status, v_msg;
+    IF v_detail IS NOT NULL AND v_detail != '' THEN
+        RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
+    END IF;
+    check_id := '51'; check_scope := 'per-database'; status := v_status; message := v_msg; detail := v_detail;
     RETURN NEXT;
     RAISE NOTICE '';
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/pg-major-version-upgrade-precheck.sh
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/pg-major-version-upgrade-precheck.sh
@@ -67,6 +67,13 @@
 #   - Check 44: User-Defined Encoding Conversions (not supported in PG >= 14) - PG <= 14 only
 #   - Check 45: User-Defined Postfix Operators (not supported in PG >= 14) - PG <= 14 only
 #   - Check 46: Incompatible Polymorphic Functions (changed in PG 14) - PG <= 14 only
+#   - Check 47: Invalid Logical Replication Slots (PG >= 17 only)
+#   - Check 47b: Inactive Logical Slots with Unconsumed WAL (PG >= 17 only)
+#   - Check 47c: Active Logical Slots with WAL Lag (PG >= 17 only)
+#   - Check 48: Subscription State Check (PG >= 17 only)
+#   - Check 49: contrib/isn and int8 Passing Mismatch
+#   - Check 50: NOT NULL Inheritance Mismatch
+#   - Check 51: Unicode-Dependent Objects (PG >= 17 only)
 #
 # Version-Specific Checks: Automatically skipped when not applicable
 #   - Check 44: User-Defined Encoding Conversions (PG <= 13 only)
@@ -1967,7 +1974,7 @@ ${db_result}
     # Critical upgrade blockers should be ERROR, not WARNING, when issues are found
     local base_check="${check_name%% - what to check:*}"
     case "${base_check}" in
-        "chkpass Extension Check"|"tsearch2 Extension Check"|"pg_repack Extension Check"|"System-Defined Composite Types in User Tables"|"aclitem Data Type Check (PostgreSQL 16+ Incompatibility)"|"sql_identifier Data Type Check (PostgreSQL 12+ Incompatibility)"|"Removed Data Types Check (abstime, reltime, tinterval)"|"Tables WITH OIDS Check"|"User-Defined Encoding Conversions Check"|"User-Defined Postfix Operators Check"|"Incompatible Polymorphic Functions Check"|"reg* Data Types in User Tables Check"|"Database Connection Settings Check")
+        "chkpass Extension Check"|"tsearch2 Extension Check"|"pg_repack Extension Check"|"System-Defined Composite Types in User Tables"|"aclitem Data Type Check (PostgreSQL 16+ Incompatibility)"|"sql_identifier Data Type Check (PostgreSQL 12+ Incompatibility)"|"Removed Data Types Check (abstime, reltime, tinterval)"|"Tables WITH OIDS Check"|"User-Defined Encoding Conversions Check"|"User-Defined Postfix Operators Check"|"Incompatible Polymorphic Functions Check"|"reg* Data Types in User Tables Check"|"Database Connection Settings Check"|"Invalid Logical Replication Slots Check"|"Inactive Logical Slots with Unconsumed WAL Check"|"Subscription State Check"|"NOT NULL Inheritance Mismatch Check")
             if [ "${status}" = "WARNING" ]; then
                 status="ERROR"
             fi
@@ -3644,12 +3651,21 @@ EOF
     start_time_15d=$(date -u -v-15d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '15 days ago' +"%Y-%m-%dT%H:%M:%SZ")
     local start_time_2h
     start_time_2h=$(date -u -v-2H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d '2 hours ago' +"%Y-%m-%dT%H:%M:%SZ")    
+
+    # Determine the correct instance identifier for CloudWatch instance-level metrics
+    # For Aurora cluster input: use writer instance; for instance input: use as-is
+    local cw_instance_id="${DB_IDENTIFIER}"
+    if [ "$is_aurora" = true ] && [ -n "${actual_instance_id:-}" ] && [ "$actual_instance_id" != "$DB_IDENTIFIER" ]; then
+        cw_instance_id="${actual_instance_id}"
+        echo "  CloudWatch instance-level metrics will use writer instance: ${cw_instance_id}"
+    fi
+
     # Check if we have 15-day data available
     local test_metric_data
     test_metric_data=$(aws cloudwatch get-metric-statistics \
         --namespace AWS/RDS \
         --metric-name "CPUUtilization" \
-        --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+        --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
         --start-time "${start_time_15d}" \
         --end-time "${end_time}" \
         --period 86400 \
@@ -3677,7 +3693,7 @@ EOF
     memory_data=$(aws cloudwatch get-metric-statistics \
         --namespace AWS/RDS \
         --metric-name "FreeableMemory" \
-        --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+        --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
         --start-time "${start_time}" \
         --end-time "${end_time}" \
         --period ${period} \
@@ -3786,7 +3802,7 @@ EOF
     cpu_data=$(aws cloudwatch get-metric-statistics \
         --namespace AWS/RDS \
         --metric-name "CPUUtilization" \
-        --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+        --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
         --start-time "${start_time}" \
         --end-time "${end_time}" \
         --period ${period} \
@@ -3820,7 +3836,7 @@ EOF
     conn_data=$(aws cloudwatch get-metric-statistics \
         --namespace AWS/RDS \
         --metric-name "DatabaseConnections" \
-        --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+        --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
         --start-time "${start_time}" \
         --end-time "${end_time}" \
         --period ${period} \
@@ -4080,6 +4096,25 @@ add_cloudwatch_metrics() {
     
     echo "Fetching CloudWatch metrics for the last 15 days..."
     
+    # Determine the correct instance identifier for CloudWatch instance-level metrics
+    # For Aurora cluster input: use writer instance; for instance input: use as-is
+    local cw_instance_id="${DB_IDENTIFIER}"
+    if [ "$ENGINE_TYPE" == "aurora-postgresql" ]; then
+        local cw_cluster_info
+        cw_cluster_info=$(aws rds describe-db-clusters \
+            --db-cluster-identifier "${CLUSTER_IDENTIFIER}" \
+            --region "${AWS_REGION}" \
+            --profile "${AWS_PROFILE}" \
+            --output json 2>/dev/null)
+        if [ $? -eq 0 ] && echo "$cw_cluster_info" | jq empty 2>/dev/null; then
+            local cw_writer
+            cw_writer=$(echo "$cw_cluster_info" | jq -r '.DBClusters[0].DBClusterMembers[] | select(.IsClusterWriter == true) | .DBInstanceIdentifier' 2>/dev/null | head -1)
+            if [ -n "$cw_writer" ] && [ "$cw_writer" != "null" ]; then
+                cw_instance_id="$cw_writer"
+            fi
+        fi
+    fi
+
     # Calculate time range (15 days)
     local end_time
     end_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -4097,7 +4132,7 @@ add_cloudwatch_metrics() {
     test_metric_data=$(aws cloudwatch get-metric-statistics \
         --namespace AWS/RDS \
         --metric-name "CPUUtilization" \
-        --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+        --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
         --start-time "${start_time_15d}" \
         --end-time "${end_time}" \
         --period 86400 \
@@ -4135,7 +4170,7 @@ EOF
         metric_data=$(aws cloudwatch get-metric-statistics \
             --namespace AWS/RDS \
             --metric-name "${metric_name}" \
-            --dimensions Name=DBInstanceIdentifier,Value="${DB_IDENTIFIER}" \
+            --dimensions Name=DBInstanceIdentifier,Value="${cw_instance_id}" \
             --start-time "${start_time}" \
             --end-time "${end_time}" \
             --period ${period} \
@@ -4871,6 +4906,13 @@ EOF
         # Detect PostgreSQL major version for version-specific checks
         get_pg_major_version
         
+        # Detect if this is Aurora PostgreSQL (for skipping checks 47-51)
+        IS_AURORA=$(PGPASSWORD="${DB_PASS}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -t -A -c "SELECT (to_regproc('aurora_version') IS NOT NULL)::text;" 2>/dev/null)
+        IS_AURORA=${IS_AURORA:-false}
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Detected: Aurora PostgreSQL (Checks 47-51 will be skipped)"
+        fi
+        
         # Check 1: PostgreSQL Version
         execute_check \
             "PostgreSQL Version Check" \
@@ -5375,15 +5417,14 @@ $(echo -e "${recommendations}" | sed 's/^/  /')
             JOIN pg_catalog.pg_attribute a ON c.oid = a.attrelid 
             WHERE NOT a.attisdropped 
                 AND a.atttypid IN ( 
-                    'pg_catalog.regproc'::pg_catalog.regtype, 
-                    'pg_catalog.regprocedure'::pg_catalog.regtype, 
-                    'pg_catalog.regoper'::pg_catalog.regtype, 
-                    'pg_catalog.regoperator'::pg_catalog.regtype, 
-                    'pg_catalog.regconfig'::pg_catalog.regtype, 
-                    'pg_catalog.regcollation'::pg_catalog.regtype, 
-                    'pg_catalog.regnamespace'::pg_catalog.regtype, 
-                    'pg_catalog.regdictionary'::pg_catalog.regtype 
+                    SELECT t.oid FROM pg_catalog.pg_type t
+                    WHERE t.typnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'pg_catalog')
+                      AND t.typname IN ('regcollation','regconfig','regdictionary','regnamespace',
+                                        'regoper','regoperator','regproc','regprocedure')
                 ) 
+                AND c.relkind IN ('r', 'm', 'i')
+                AND n.nspname !~ '^pg_temp_'
+                AND n.nspname !~ '^pg_toast_temp_'
                 AND n.nspname NOT IN ('pg_catalog', 'information_schema');
             -- Check for unsupported reg* data types 
             SELECT 
@@ -5396,15 +5437,14 @@ $(echo -e "${recommendations}" | sed 's/^/  /')
             JOIN pg_catalog.pg_attribute a ON c.oid = a.attrelid 
             WHERE NOT a.attisdropped 
                 AND a.atttypid IN ( 
-                    'pg_catalog.regproc'::pg_catalog.regtype, 
-                    'pg_catalog.regprocedure'::pg_catalog.regtype, 
-                    'pg_catalog.regoper'::pg_catalog.regtype, 
-                    'pg_catalog.regoperator'::pg_catalog.regtype, 
-                    'pg_catalog.regconfig'::pg_catalog.regtype, 
-                    'pg_catalog.regcollation'::pg_catalog.regtype, 
-                    'pg_catalog.regnamespace'::pg_catalog.regtype, 
-                    'pg_catalog.regdictionary'::pg_catalog.regtype 
+                    SELECT t.oid FROM pg_catalog.pg_type t
+                    WHERE t.typnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'pg_catalog')
+                      AND t.typname IN ('regcollation','regconfig','regdictionary','regnamespace',
+                                        'regoper','regoperator','regproc','regprocedure')
                 ) 
+                AND c.relkind IN ('r', 'm', 'i')
+                AND n.nspname !~ '^pg_temp_'
+                AND n.nspname !~ '^pg_toast_temp_'
                 AND n.nspname NOT IN ('pg_catalog', 'information_schema') 
             ORDER BY n.nspname, c.relname, a.attname;" \
             "${output_file}" \
@@ -6321,6 +6361,193 @@ Details: ${upgrade_targets}"
                 "46"
         else
             echo "Skipping Check 46 (Incompatible Polymorphic Functions) - Not applicable for PostgreSQL > 14"
+        fi
+        
+        # Check 47: Invalid Logical Replication Slots - Only for PG >= 17
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 47 (Invalid Logical Replication Slots) - Not applicable for Aurora PostgreSQL"
+        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+            execute_check_all_dbs \
+                "Invalid Logical Replication Slots Check - what to check: \"Your installation contains invalidated logical replication slots. These slots cannot be migrated during pg_upgrade. Drop them before upgrading.\"" \
+                "Check for logical replication slots with invalidation_reason IS NOT NULL (PostgreSQL >= 17 slot migration)" \
+                "SELECT 
+                    slot_name,
+                    plugin,
+                    database,
+                    invalidation_reason,
+                    'CRITICAL - Invalid logical slot cannot be migrated' AS issue
+                FROM pg_catalog.pg_replication_slots
+                WHERE slot_type = 'logical'
+                  AND temporary = false
+                  AND invalidation_reason IS NOT NULL
+                ORDER BY slot_name;" \
+                "${output_file}" \
+                "47"
+        else
+            echo "Skipping Check 47 (Invalid Logical Replication Slots) - Not applicable for PostgreSQL < 17"
+        fi
+        
+        # Check 47b: Inactive Logical Slots with Unconsumed WAL - Only for PG >= 17
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 47b (Inactive Logical Slots with Unconsumed WAL) - Not applicable for Aurora PostgreSQL"
+        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+            execute_check_all_dbs \
+                "Inactive Logical Slots with Unconsumed WAL Check - what to check: \"Your installation contains inactive logical replication slots with unconsumed WAL. After shutdown, pg_upgrade will reject these. Either consume pending WAL or drop the slot(s).\"" \
+                "Check for inactive logical slots that have not consumed all WAL (PostgreSQL >= 17 slot migration)" \
+                "SELECT 
+                    slot_name,
+                    plugin,
+                    database,
+                    confirmed_flush_lsn,
+                    pg_current_wal_insert_lsn() AS current_wal_insert_lsn,
+                    pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) AS wal_lag,
+                    'CRITICAL - Inactive slot with unconsumed WAL will block pg_upgrade' AS issue
+                FROM pg_catalog.pg_replication_slots
+                WHERE slot_type = 'logical'
+                  AND temporary = false
+                  AND active = false
+                  AND invalidation_reason IS NULL
+                  AND confirmed_flush_lsn < pg_current_wal_insert_lsn()
+                ORDER BY slot_name;" \
+                "${output_file}" \
+                "47b"
+        else
+            echo "Skipping Check 47b (Inactive Logical Slots with Unconsumed WAL) - Not applicable for PostgreSQL < 17"
+        fi
+        
+        # Check 47c: Active Logical Slots with WAL Lag - Only for PG >= 17 (WARNING only)
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 47c (Active Logical Slots with WAL Lag) - Not applicable for Aurora PostgreSQL"
+        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+            execute_check_all_dbs \
+                "Active Logical Slots with WAL Lag Check" \
+                "Check for active logical slots with WAL lag - ensure consumers are caught up before stopping for upgrade (PostgreSQL >= 17)" \
+                "SELECT 
+                    slot_name,
+                    plugin,
+                    database,
+                    confirmed_flush_lsn,
+                    pg_current_wal_insert_lsn() AS current_wal_insert_lsn,
+                    pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) AS wal_lag,
+                    'WARNING - Active slot with WAL lag; ensure consumer catches up before upgrade' AS issue
+                FROM pg_catalog.pg_replication_slots
+                WHERE slot_type = 'logical'
+                  AND temporary = false
+                  AND active = true
+                  AND invalidation_reason IS NULL
+                  AND confirmed_flush_lsn < pg_current_wal_insert_lsn()
+                ORDER BY slot_name;" \
+                "${output_file}" \
+                "47c"
+        else
+            echo "Skipping Check 47c (Active Logical Slots with WAL Lag) - Not applicable for PostgreSQL < 17"
+        fi
+        
+        # Check 48: Subscription State Check - Only for PG >= 17
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 48 (Subscription State Check) - Not applicable for Aurora PostgreSQL"
+        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+            execute_check_all_dbs \
+                "Subscription State Check - what to check: \"Your installation contains subscriptions without replication origin or having relations not in i (initialize) or r (ready) state. Fix before upgrading.\"" \
+                "Check subscription replication origins and relation states for pg_upgrade compatibility (PostgreSQL >= 17)" \
+                "SELECT s.subname AS subscription, '(missing replication origin)' AS issue
+                FROM pg_catalog.pg_subscription s
+                LEFT JOIN pg_catalog.pg_replication_origin o
+                       ON o.roname = 'pg_' || s.oid::text
+                WHERE o.roname IS NULL
+                UNION ALL
+                SELECT s.subname || '.' || c.relname, 'state=' || r.srsubstate::text
+                FROM pg_catalog.pg_subscription_rel r
+                JOIN pg_catalog.pg_subscription s ON r.srsubid = s.oid
+                JOIN pg_catalog.pg_class c        ON r.srrelid = c.oid
+                WHERE r.srsubstate NOT IN ('i', 'r')
+                ORDER BY 1;" \
+                "${output_file}" \
+                "48"
+        else
+            echo "Skipping Check 48 (Subscription State Check) - Not applicable for PostgreSQL < 17"
+        fi
+        
+        # Check 49: contrib/isn and int8 Passing Mismatch (all versions, WARNING)
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 49 (contrib/isn Extension) - Not applicable for Aurora PostgreSQL"
+        else
+        execute_check_all_dbs \
+            "contrib/isn Extension Check" \
+            "Check for contrib/isn functions - if old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. On RDS this is normally consistent." \
+            "SELECT 
+                n.nspname AS schema_name,
+                p.proname AS function_name,
+                'WARNING - contrib/isn function found; verify float8_pass_by_value consistency' AS issue
+            FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+            WHERE p.probin = '\$libdir/isn'
+            ORDER BY n.nspname, p.proname;" \
+            "${output_file}" \
+            "49"
+        fi
+        
+        # Check 50: NOT NULL Inheritance Mismatch (all versions)
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 50 (NOT NULL Inheritance Mismatch) - Not applicable for Aurora PostgreSQL"
+        else
+        execute_check_all_dbs \
+            "NOT NULL Inheritance Mismatch Check - what to check: \"Your installation contains child tables that omit NOT NULL constraints present in their parent tables. This will cause pg_upgrade to fail when upgrading to PostgreSQL 18+. Fix with: ALTER TABLE child ALTER COLUMN col SET NOT NULL.\"" \
+            "Check for child tables missing NOT NULL constraints that parent tables have" \
+            "SELECT 
+                nc.nspname AS schema_name,
+                cc.relname AS child_table,
+                ac.attname AS column_name,
+                np.nspname || '.' || cp.relname AS parent_table,
+                'CRITICAL - Child missing NOT NULL that parent has' AS issue
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_attribute ac ON ac.attrelid = i.inhrelid
+            JOIN pg_catalog.pg_attribute ap ON ap.attrelid = i.inhparent AND ap.attname = ac.attname
+            JOIN pg_catalog.pg_class cc ON cc.oid = i.inhrelid
+            JOIN pg_catalog.pg_namespace nc ON nc.oid = cc.relnamespace
+            JOIN pg_catalog.pg_class cp ON cp.oid = i.inhparent
+            JOIN pg_catalog.pg_namespace np ON np.oid = cp.relnamespace
+            WHERE ap.attnum > 0
+              AND ap.attnotnull
+              AND NOT ac.attnotnull
+            ORDER BY nc.nspname, cc.relname, ac.attname;" \
+            "${output_file}" \
+            "50"
+        fi
+        
+        # Check 51: Unicode-Dependent Objects - Only for PG >= 17 (WARNING only)
+        if [ "$IS_AURORA" = "true" ]; then
+            echo "Skipping Check 51 (Unicode-Dependent Objects) - Not applicable for Aurora PostgreSQL"
+        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+            execute_check_all_dbs \
+                "Unicode-Dependent Objects Check" \
+                "Check for indexes/partitions/constraints using Unicode-dependent functions (lower, upper, initcap, regexp_*). If Unicode version differs between old and new clusters, consider REINDEX after upgrade." \
+                "SELECT 
+                    n.nspname AS schema_name,
+                    c.relname AS relation_name,
+                    ic.relname AS index_name,
+                    'WARNING - Expression index uses Unicode-dependent function' AS issue
+                FROM pg_catalog.pg_index ix
+                JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
+                JOIN pg_catalog.pg_class c  ON c.oid  = ix.indrelid
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE ix.indexprs IS NOT NULL
+                  AND EXISTS (
+                      SELECT 1 FROM pg_catalog.pg_proc f
+                      JOIN pg_catalog.pg_namespace fn ON f.pronamespace = fn.oid
+                      WHERE fn.nspname = 'pg_catalog'
+                        AND (f.proname IN ('normalize','unicode_assigned','unicode_version','is_normalized',
+                                           'lower','upper','initcap','casefold')
+                             OR f.proname LIKE 'regexp_%')
+                        AND (ix.indexprs::text LIKE '%:funcid ' || f.oid || ' %'
+                             OR ix.indpred::text LIKE '%:funcid ' || f.oid || ' %')
+                  )
+                ORDER BY n.nspname, c.relname, ic.relname
+                LIMIT 50;" \
+                "${output_file}" \
+                "51"
+        else
+            echo "Skipping Check 51 (Unicode-Dependent Objects) - Not applicable for PostgreSQL < 17"
         fi
         
         # Close the checks table (HTML only)

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/README.md
@@ -2,7 +2,7 @@
 
 Run this tool before performing a Major Version Upgrade on RDS/Aurora PostgreSQL to detect common issues that may cause the upgrade to fail.
 
-Supported target versions: PostgreSQL 11 – 17
+Supported target versions: PostgreSQL 11 – 18
 
 > **Note:** These SQL scripts must be executed against each database individually. If you need automated execution across all databases in a cluster, use the [shell script version](https://github.com/awslabs/rds-support-tools/tree/main/postgres/diag/shell/pg-major-version-upgrade-precheck-tool) which iterates all user databases automatically.
 

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/pg-major-version-upgrade-precheck-sql.sql
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/pg-major-version-upgrade-precheck-sql.sql
@@ -17,7 +17,7 @@
 -- ============================================
 -- Aurora/RDS PostgreSQL Major Version Upgrade Precheck
 -- SQL Version
--- Supports: Target Major Version 11-17
+-- Supports: Target Major Version 11-18
 --
 -- Each check is either:
 --   [global]       - Run once against the postgres database
@@ -117,10 +117,13 @@ SELECT
   (current_setting('server_version_num')::int / 10000 < 17)::text                AS need_slot_check,
   (:target_version >= 11)::text                                                   AS target_ge_11,
   (:target_version >= 14)::text                                                   AS target_ge_14,
+  (:target_version >= 18)::text                                                   AS target_ge_18,
+  (current_setting('server_version_num')::int / 10000 >= 17)::text               AS source_ge_17,
   (current_setting('server_version_num')::int / 10000 <= 15
      AND :target_version >= 16)::text                                             AS need_aclitem_check,
   (current_setting('server_version_num')::int / 10000 <= 11)::text               AS source_le_11,
-  (current_setting('server_version_num')::int / 10000 <= 13)::text               AS source_le_13
+  (current_setting('server_version_num')::int / 10000 <= 13)::text               AS source_le_13,
+  (to_regproc('aurora_version') IS NOT NULL)::text                               AS is_aurora
 \gset
 
 -- Version sanity check
@@ -130,11 +133,21 @@ SELECT
 \endif
 
 -- ============================================
--- Validate target_version is within supported range (11-17)
+-- Validate target_version is within supported range (11-18)
 -- ============================================
-SELECT (:target_version < 11 OR :target_version > 17)::text AS version_out_of_range \gset
+SELECT (:target_version < 11 OR :target_version > 18)::text AS version_out_of_range \gset
 \if :version_out_of_range
-    \echo '❌ FAILED: target_version must be between 11 and 17.'
+    \echo '❌ FAILED: target_version must be between 11 and 18.'
+    \quit
+\endif
+
+-- ============================================
+-- Aurora PostgreSQL does not yet support target version 18
+-- ============================================
+SELECT (to_regproc('aurora_version') IS NOT NULL AND :target_version >= 18)::text AS aurora_target_invalid \gset
+\if :aurora_target_invalid
+    \echo '❌ FAILED: Aurora PostgreSQL does not support target version 18 yet.'
+    \echo '   Supported target versions for Aurora PostgreSQL: 11-17'
     \quit
 \endif
 
@@ -478,7 +491,7 @@ WHERE state != 'idle'
     \endif
 \else
     SELECT 'false' AS c13_failed, '- SKIP' AS c13_status \gset
-    \echo '- Skipped (APG 17+ supports logical slot migration)'
+    \echo '- Skipped (PG 17+ supports logical slot migration)'
 \endif
 
 \echo ''
@@ -1824,6 +1837,409 @@ FROM (
 
 \echo ''
 
+-- --------------------------------------------
+-- Check 47. check_old_cluster_for_valid_slots - invalid slots [global]
+-- (source >= 17; logical slot migration requires valid slots)
+-- (Skipped for Aurora PostgreSQL - Aurora handles slot migration internally)
+-- --------------------------------------------
+\echo '=== 47. check_old_cluster_for_valid_slots - invalid slots [global] ==='
+\if :is_aurora
+    SELECT 'false' AS c47_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\elif :source_ge_17
+    SELECT (count(*) > 0)::text AS c47_failed,
+           CASE WHEN count(*) > 0
+                THEN '❌ FAILED: ' || count(*) || ' invalidated logical slot(s). Drop them before upgrade.'
+                ELSE '✓ PASSED'
+           END AS c47_status
+    FROM pg_catalog.pg_replication_slots
+    WHERE slot_type = 'logical'
+      AND temporary = false
+      AND invalidation_reason IS NOT NULL \gset
+
+    \echo :c47_status
+
+    \if :c47_failed
+        SELECT slot_name, plugin, database, invalidation_reason
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND invalidation_reason IS NOT NULL;
+    \endif
+\else
+    SELECT 'false' AS c47_failed, '- SKIP' AS c47_status \gset
+    \echo '- Skipped (source version < 17; logical slot migration not applicable)'
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global]
+-- (source >= 17; inactive slots must have consumed all WAL before shutdown)
+-- --------------------------------------------
+\echo '=== 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global] ==='
+\if :is_aurora
+    SELECT 'false' AS c47b_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\elif :source_ge_17
+    SELECT (count(*) > 0)::text AS c47b_failed,
+           CASE WHEN count(*) > 0
+                THEN '❌ FAILED: ' || count(*) || ' inactive logical slot(s) with unconsumed WAL. '
+                     || 'After shutdown, pg_upgrade will reject these. '
+                     || 'Either consume pending WAL or drop the slot(s).'
+                ELSE '✓ PASSED'
+           END AS c47b_status
+    FROM pg_catalog.pg_replication_slots
+    WHERE slot_type = 'logical'
+      AND temporary = false
+      AND active = false
+      AND invalidation_reason IS NULL
+      AND confirmed_flush_lsn < pg_current_wal_insert_lsn() \gset
+
+    \echo :c47b_status
+
+    \if :c47b_failed
+        SELECT slot_name, plugin, database,
+               confirmed_flush_lsn,
+               pg_current_wal_insert_lsn() AS current_wal_insert_lsn,
+               pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) AS wal_lag
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND active = false
+          AND invalidation_reason IS NULL
+          AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+    \endif
+\else
+    SELECT 'false' AS c47b_failed, '- SKIP' AS c47b_status \gset
+    \echo '- Skipped (source version < 17)'
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 47c. check_old_cluster_for_valid_slots - active slots with lag [global]
+-- (source >= 17; WARNING only - active slots with WAL lag may fail
+-- --------------------------------------------
+\echo '=== 47c. check_old_cluster_for_valid_slots - active slots with WAL lag [global] ==='
+\if :is_aurora
+    SELECT 'false' AS c47c_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\elif :source_ge_17
+    SELECT (count(*) > 0)::text AS c47c_failed,
+           CASE WHEN count(*) > 0
+                THEN '⚠️ WARNING: ' || count(*) || ' active logical slot(s) with WAL lag. '
+                     || 'Ensure consumers are caught up before stopping the instance for upgrade.'
+                ELSE '✓ PASSED'
+           END AS c47c_status
+    FROM pg_catalog.pg_replication_slots
+    WHERE slot_type = 'logical'
+      AND temporary = false
+      AND active = true
+      AND invalidation_reason IS NULL
+      AND confirmed_flush_lsn < pg_current_wal_insert_lsn() \gset
+
+    \echo :c47c_status
+
+    \if :c47c_failed
+        SELECT slot_name, plugin, database,
+               confirmed_flush_lsn,
+               pg_current_wal_insert_lsn() AS current_wal_insert_lsn,
+               pg_size_pretty(pg_current_wal_insert_lsn() - confirmed_flush_lsn) AS wal_lag
+        FROM pg_catalog.pg_replication_slots
+        WHERE slot_type = 'logical'
+          AND temporary = false
+          AND active = true
+          AND invalidation_reason IS NULL
+          AND confirmed_flush_lsn < pg_current_wal_insert_lsn();
+    \endif
+
+    -- Info: show all logical slots
+    \echo '  --- All logical slots (info) ---'
+    SELECT slot_name, plugin, database, active, wal_status,
+           confirmed_flush_lsn,
+           pg_current_wal_insert_lsn() AS current_wal_insert_lsn
+    FROM pg_catalog.pg_replication_slots
+    WHERE slot_type = 'logical'
+    ORDER BY slot_name;
+\else
+    SELECT 'false' AS c47c_failed, '- SKIP' AS c47c_status \gset
+    \echo '- Skipped (source version < 17)'
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 48. check_old_cluster_subscription_state [per-database]
+-- (source >= 17; subscription relations must be in 'i' or 'r' state,
+--  and each subscription must have a replication origin)
+-- --------------------------------------------
+\echo '=== 48. check_old_cluster_subscription_state [per-database] ==='
+\if :is_aurora
+    SELECT 'false' AS c48_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\elif :source_ge_17
+    SELECT (count(*) > 0)::text AS c48_failed,
+           CASE WHEN count(*) > 0
+                THEN '❌ FAILED: ' || count(*) || ' subscription issue(s) found. Fix before upgrade.'
+                ELSE '✓ PASSED'
+           END AS c48_status
+    FROM (
+        -- Subscriptions missing replication origin
+        SELECT s.subname AS item
+        FROM pg_catalog.pg_subscription s
+        LEFT JOIN pg_catalog.pg_replication_origin o
+               ON o.roname = 'pg_' || s.oid::text
+        WHERE o.roname IS NULL
+        UNION ALL
+        -- Subscription relations not in i/r state
+        SELECT s.subname || '.' || c.relname
+        FROM pg_catalog.pg_subscription_rel r
+        JOIN pg_catalog.pg_subscription s ON r.srsubid = s.oid
+        JOIN pg_catalog.pg_class c        ON r.srrelid = c.oid
+        WHERE r.srsubstate NOT IN ('i', 'r')
+    ) sub \gset
+
+    \echo :c48_status
+
+    \if :c48_failed
+        -- Subscriptions missing origin
+        SELECT s.subname AS subscription, '(missing replication origin)' AS issue
+        FROM pg_catalog.pg_subscription s
+        LEFT JOIN pg_catalog.pg_replication_origin o
+               ON o.roname = 'pg_' || s.oid::text
+        WHERE o.roname IS NULL
+        ORDER BY s.subname;
+
+        -- Relations in unsupported state
+        SELECT s.subname AS subscription,
+               n.nspname AS schema,
+               c.relname AS relation,
+               r.srsubstate AS state
+        FROM pg_catalog.pg_subscription_rel r
+        JOIN pg_catalog.pg_subscription s ON r.srsubid = s.oid
+        JOIN pg_catalog.pg_class c        ON r.srrelid = c.oid
+        JOIN pg_catalog.pg_namespace n    ON c.relnamespace = n.oid
+        WHERE r.srsubstate NOT IN ('i', 'r')
+        ORDER BY s.subname, n.nspname, c.relname;
+    \endif
+\else
+    SELECT 'false' AS c48_failed, '- SKIP' AS c48_status \gset
+    \echo '- Skipped (source version < 17)'
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 49. check_for_isn_and_int8_passing_mismatch [per-database]
+-- --------------------------------------------
+\echo '=== 49. check_for_isn_and_int8_passing_mismatch [per-database] ==='
+\if :is_aurora
+    SELECT 'false' AS c49_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\else
+SELECT (count(*) > 0)::text AS c49_failed,
+       CASE WHEN count(*) > 0
+            THEN '⚠️ WARNING: ' || count(*) || ' contrib/isn function(s) found. ' ||
+                 'If old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. ' ||
+                 'On RDS this is normally consistent, but verify before upgrading.'
+            ELSE '✓ PASSED'
+       END AS c49_status
+FROM pg_catalog.pg_proc p
+WHERE p.probin = '$libdir/isn' \gset
+
+\echo :c49_status
+
+\if :c49_failed
+    SELECT n.nspname AS schema, p.proname AS function_name
+    FROM pg_catalog.pg_proc p
+    JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+    WHERE p.probin = '$libdir/isn'
+    ORDER BY n.nspname, p.proname;
+\endif
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 50. check_for_not_null_inheritance [per-database]
+-- (PG18 new; target >= 18)
+-- Child tables must not omit NOT NULL constraints that parents have.
+-- --------------------------------------------
+\echo '=== 50. check_for_not_null_inheritance [per-database] ==='
+\if :is_aurora
+    SELECT 'false' AS c50_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\elif :target_ge_18
+    SELECT (count(*) > 0)::text AS c50_failed,
+           CASE WHEN count(*) > 0
+                THEN '❌ FAILED: ' || count(*) || ' child column(s) missing NOT NULL inherited from parent. ' ||
+                     'Run ALTER TABLE child ALTER col SET NOT NULL on each.'
+                ELSE '✓ PASSED'
+           END AS c50_status
+    FROM pg_catalog.pg_inherits i
+    JOIN pg_catalog.pg_attribute ac ON i.inhrelid  = ac.attrelid
+    JOIN pg_catalog.pg_attribute ap ON i.inhparent = ap.attrelid
+                                   AND ac.attname  = ap.attname
+    JOIN pg_catalog.pg_class cc     ON cc.oid = ac.attrelid
+    JOIN pg_catalog.pg_namespace nc ON nc.oid = cc.relnamespace
+    WHERE ap.attnum > 0
+      AND ap.attnotnull
+      AND NOT ac.attnotnull \gset
+
+    \echo :c50_status
+
+    \if :c50_failed
+        SELECT nc.nspname AS schema, cc.relname AS child_table, ac.attname AS column_name
+        FROM pg_catalog.pg_inherits i
+        JOIN pg_catalog.pg_attribute ac ON i.inhrelid  = ac.attrelid
+        JOIN pg_catalog.pg_attribute ap ON i.inhparent = ap.attrelid
+                                       AND ac.attname  = ap.attname
+        JOIN pg_catalog.pg_class cc     ON cc.oid = ac.attrelid
+        JOIN pg_catalog.pg_namespace nc ON nc.oid = cc.relnamespace
+        WHERE ap.attnum > 0
+          AND ap.attnotnull
+          AND NOT ac.attnotnull
+        ORDER BY nc.nspname, cc.relname, ac.attname;
+    \endif
+\else
+    SELECT 'false' AS c50_failed, '- SKIP' AS c50_status \gset
+    \echo '- Skipped (only applicable when target >= 18)'
+\endif
+
+\echo ''
+
+-- --------------------------------------------
+-- Check 51. check_for_unicode_update [per-database]
+-- (PG18 new; source >= 17 and target >= 18)
+-- WARNING only - does not block pg_upgrade.
+-- Surfaces indexes/partitions/constraints/matviews that use
+-- Unicode-dependent functions which may produce different results
+-- if the Unicode version changed between old and new clusters.
+-- --------------------------------------------
+\echo '=== 51. check_for_unicode_update [per-database] ==='
+\if :is_aurora
+    SELECT 'false' AS c51_failed \gset
+    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
+\else
+SELECT (:source_ge_17 = 'true' AND :target_ge_18 = 'true')::text AS need_c51 \gset
+\if :need_c51
+    WITH
+    coll_dependent_funcs AS (
+        SELECT p.oid
+        FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+        WHERE n.nspname = 'pg_catalog'
+          AND ( p.proname IN ('normalize','unicode_assigned',
+                              'unicode_version','is_normalized',
+                              'lower','upper','initcap','casefold')
+             OR p.proname LIKE 'regexp_%' )
+    ),
+    coll_dependent_ops AS (
+        SELECT op.oid
+        FROM pg_catalog.pg_operator op
+        JOIN pg_catalog.pg_namespace n ON op.oprnamespace = n.oid
+        WHERE n.nspname = 'pg_catalog'
+          AND op.oprname IN ('~','~*','!~','!~*','~~*','!~~*')
+    ),
+    affected AS (
+        SELECT ix.indexrelid AS reloid
+        FROM pg_catalog.pg_index ix
+        WHERE EXISTS (
+            SELECT 1 FROM coll_dependent_funcs f
+            WHERE ix.indexprs::text LIKE '%:funcid ' || f.oid || ' %'
+               OR ix.indpred::text  LIKE '%:funcid ' || f.oid || ' %'
+        )
+        OR EXISTS (
+            SELECT 1 FROM coll_dependent_ops o
+            WHERE ix.indexprs::text LIKE '%:opno ' || o.oid || ' %'
+               OR ix.indpred::text  LIKE '%:opno ' || o.oid || ' %'
+        )
+        UNION ALL
+        SELECT pt.partrelid
+        FROM pg_catalog.pg_partitioned_table pt
+        WHERE EXISTS (
+            SELECT 1 FROM coll_dependent_funcs f
+            WHERE pt.partexprs::text LIKE '%:funcid ' || f.oid || ' %'
+        )
+        UNION ALL
+        SELECT co.conrelid
+        FROM pg_catalog.pg_constraint co
+        WHERE co.conbin IS NOT NULL
+          AND ( EXISTS (
+                  SELECT 1 FROM coll_dependent_funcs f
+                  WHERE co.conbin::text LIKE '%:funcid ' || f.oid || ' %')
+             OR EXISTS (
+                  SELECT 1 FROM coll_dependent_ops o
+                  WHERE co.conbin::text LIKE '%:opno ' || o.oid || ' %') )
+        UNION ALL
+        SELECT rw.ev_class
+        FROM pg_catalog.pg_rewrite rw
+        JOIN pg_catalog.pg_class c ON c.oid = rw.ev_class
+        WHERE c.relkind = 'm'
+          AND ( EXISTS (
+                  SELECT 1 FROM coll_dependent_funcs f
+                  WHERE rw.ev_action::text LIKE '%:funcid ' || f.oid || ' %')
+             OR EXISTS (
+                  SELECT 1 FROM coll_dependent_ops o
+                  WHERE rw.ev_action::text LIKE '%:opno ' || o.oid || ' %') )
+    )
+    SELECT (count(*) > 0)::text AS c51_failed,
+           CASE WHEN count(*) > 0
+                THEN '⚠️ WARNING: ' || count(*) || ' object(s) reference Unicode-dependent functions/operators. ' ||
+                     'If the Unicode version differs between old and new clusters, consider REINDEX or rebuilding affected objects after upgrade.'
+                ELSE '✓ PASSED'
+           END AS c51_status
+    FROM affected \gset
+
+    \echo :c51_status
+
+    \if :c51_failed
+        WITH
+        coll_dependent_funcs AS (
+            SELECT p.oid
+            FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace n ON p.pronamespace = n.oid
+            WHERE n.nspname = 'pg_catalog'
+              AND ( p.proname IN ('normalize','unicode_assigned',
+                                  'unicode_version','is_normalized',
+                                  'lower','upper','initcap','casefold')
+                 OR p.proname LIKE 'regexp_%' )
+        ),
+        coll_dependent_ops AS (
+            SELECT op.oid
+            FROM pg_catalog.pg_operator op
+            JOIN pg_catalog.pg_namespace n ON op.oprnamespace = n.oid
+            WHERE n.nspname = 'pg_catalog'
+              AND op.oprname IN ('~','~*','!~','!~*','~~*','!~~*')
+        )
+        SELECT 'index'::text AS kind,
+               n.nspname AS schema,
+               c.relname AS table_name,
+               ic.relname AS index_name
+        FROM pg_catalog.pg_index ix
+        JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
+        JOIN pg_catalog.pg_class c  ON c.oid  = ix.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE EXISTS (
+            SELECT 1 FROM coll_dependent_funcs f
+            WHERE ix.indexprs::text LIKE '%:funcid ' || f.oid || ' %'
+               OR ix.indpred::text  LIKE '%:funcid ' || f.oid || ' %')
+        OR EXISTS (
+            SELECT 1 FROM coll_dependent_ops o
+            WHERE ix.indexprs::text LIKE '%:opno ' || o.oid || ' %'
+               OR ix.indpred::text  LIKE '%:opno ' || o.oid || ' %')
+        ORDER BY n.nspname, c.relname, ic.relname
+        LIMIT 50;
+    \endif
+\else
+    SELECT 'false' AS c51_failed, '- SKIP' AS c51_status \gset
+    \echo '- Skipped (only meaningful when source >= 17 and target >= 18)'
+\endif
+\endif
+
+\echo ''
+
 -- ============================================
 -- Summary
 -- ============================================
@@ -1847,7 +2263,8 @@ FROM (VALUES
     ('36', :'c36_failed'), ('37', :'c37_failed'), ('38', :'c38_failed'),
     ('39', :'c39_failed'), ('39b', :'c39b_failed'), ('40', :'c40_failed'),
     ('41', :'c41_failed'), ('42', :'c42_failed'), ('43', :'c43_failed'),
-    ('44', :'c44_failed'), ('45', :'c45_failed'), ('46', :'c46_failed')
+    ('44', :'c44_failed'), ('45', :'c45_failed'), ('46', :'c46_failed'),
+    ('47', :'c47_failed'), ('47b', :'c47b_failed'), ('48', :'c48_failed'), ('50', :'c50_failed')
 ) AS t(check_name, failed)
 WHERE failed = 'true';
 
@@ -1865,7 +2282,9 @@ FROM (VALUES
     ('26', :'c26_failed'),
     ('27', :'c27_failed'), ('28', :'c28_failed'), ('29', :'c29_failed'),
     ('31', :'c31_failed'), ('32', :'c32_failed'), ('34', :'c34_failed'),
-    ('35', :'c35_failed'), ('35c', :'c35c_failed')
+    ('35', :'c35_failed'), ('35c', :'c35c_failed'),
+    ('47c', :'c47c_failed'),
+    ('49', :'c49_failed'), ('51', :'c51_failed')
 ) AS t(check_name, failed)
 WHERE failed = 'true';
 

--- a/postgres/postgres.README
+++ b/postgres/postgres.README
@@ -93,7 +93,7 @@ pg-major-version-upgrade-precheck.sh            :   Aurora/RDS PostgreSQL Major 
                                         Prerequisites:
                                             bash 4.0+, psql, aws cli (for RDS mode), jq
 
-                                        Tested on RDS PostgreSQL 11-17, Aurora PostgreSQL 11-17
+                                        Tested on RDS PostgreSQL 11-18, Aurora PostgreSQL 11-17
 
 wrapper.sh                          :   Batch execution wrapper for pg-major-version-upgrade-precheck.sh.
                                         Runs pre-upgrade checks against multiple PostgreSQL databases
@@ -122,7 +122,7 @@ wrapper.sh                          :   Batch execution wrapper for pg-major-ver
                                             bash 4.0+, psql, aws cli, jq
                                             pg-major-version-upgrade-precheck.sh in the same directory
 
-                                        Tested on RDS PostgreSQL 11-17, Aurora PostgreSQL 11-17
+                                        Tested on RDS PostgreSQL 11-18, Aurora PostgreSQL 11-17
 
 ################################################################################
 rds-support-tools/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/
@@ -148,7 +148,7 @@ pg-major-version-upgrade-precheck-sql.sql                :   Aurora/RDS PostgreS
                                                             Prerequisites:
                                                                 Any PostgreSQL client (psql. etc.)
 
-                                                            Tested on RDS PostgreSQL 11-17, Aurora PostgreSQL 11-17
+                                                            Tested on RDS PostgreSQL 11-18, Aurora PostgreSQL 11-17
 
 ################################################################################
 rds-support-tools/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/
@@ -182,7 +182,7 @@ pg-major-version-upgrade-precheck-plpgsql.sql            :   Aurora/RDS PostgreS
                                                             Prerequisites:
                                                                 Any PostgreSQL client (psql. etc.)
 
-                                                            Tested on RDS PostgreSQL 11-17, Aurora PostgreSQL 11-17
+                                                            Tested on RDS PostgreSQL 11-18, Aurora PostgreSQL 11-17
 
 #####################################
 rds-support-tools/postgres/diag/proc


### PR DESCRIPTION
Bug fixes:
- Fix Check 19 (reg* data types) syntax error on source PG 11/12 by replacing regtype cast with pg_type.typname lookup (regcollation does not exist before PG 13)
- Fix wrapper.sh CloudWatch metrics collection returning 0 for Aurora clusters when cluster identifier is provided instead of instance identifier; now resolves writer instance ID automatically

New features:
- Add target version 18 precheck items (Checks 47-51).
- Aurora PostgreSQL engine detection:
  - Shell: Automatically skips Checks 47-51 for Aurora instances
  - SQL/PL/pgSQL: Blocks execution with clear message when target_version >= 18 is specified on Aurora (not yet supported); skips Checks 47-51 for lower target versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
