### PR TITLE
feat: Adjusted the checks to support upgrading Aurora PostgreSQL to m…

### DIFF
--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/README.md
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/README.md
@@ -1,0 +1,81 @@
+# Aurora / RDS for PostgreSQL Major Version Upgrade Pre-Check Tool
+
+> AWS pre-upgrade check tool for **Amazon Aurora PostgreSQL** and
+> **Amazon RDS for PostgreSQL**, maintained under
+> [awslabs/rds-support-tools](https://github.com/awslabs/rds-support-tools).
+
+This tool helps you **identify potential issues before a PostgreSQL major
+version upgrade**. It performs a comprehensive set of pre-upgrade readiness
+checks across every database in a cluster so you can find and fix blockers
+before you run the upgrade, and validate readiness for **Blue/Green
+deployments**.
+
+**Keywords:** PostgreSQL pre-upgrade check, RDS PostgreSQL major version
+upgrade, Aurora PostgreSQL upgrade precheck, pg_upgrade compatibility check,
+Blue/Green deployment readiness.
+
+## Why use this tool
+
+- Runs **51 comprehensive checks** to validate major version upgrade readiness.
+- Detects upgrade **blockers** (unsupported data types, incompatible
+  extensions, `reg*` types, unknown-type columns, and more) before they cause a
+  failed or rolled-back upgrade.
+- Validates **Blue/Green deployment** prerequisites (logical replication
+  settings, sequences, unsupported features).
+- Analyzes RDS/Aurora configuration and CloudWatch metrics.
+- Works against **Aurora/RDS PostgreSQL 11–18**.
+
+## Available versions
+
+| Version | Path | Best for |
+| --- | --- | --- |
+| **Shell script** | [`shell/`](./shell) | Full automation, cross-database iteration, HTML/text reports, AWS Secrets Manager, batch runs via `wrapper.sh` |
+| **SQL (psql)** | [`sql/`](./sql) | Pure `psql` meta-command script, no shell required, run per database |
+| **PL/pgSQL** | [`plpgsql/`](./plpgsql) | Callable function from any PostgreSQL client, run per database |
+
+## Quick start (shell version)
+
+Interactive:
+
+```bash
+bash pg-major-version-upgrade-precheck.sh
+```
+
+Non-interactive:
+
+```bash
+bash pg-major-version-upgrade-precheck.sh --non-interactive -m sql \
+    -h <endpoint> -P <port> -d <database> -u <user> -w <password>
+```
+
+With Blue/Green checks and both check modes:
+
+```bash
+bash pg-major-version-upgrade-precheck.sh --non-interactive --blue-green -m both \
+    -r <region> -i <identifier> -p <profile> \
+    -h <endpoint> -P <port> -d <database> -u <user> -s <secret-arn>
+```
+
+Output: `rds_precheck_report_<identifier>_<timestamp>.html` (or `.txt`).
+
+Prerequisites: `bash 4.0+`, `psql`, `aws cli` (for RDS mode), `jq`.
+
+## What it checks
+
+- **25 standard pre-upgrade checks** (always executed)
+- **14 Blue/Green deployment checks** (optional, `--blue-green`)
+- **12 critical upgrade blocker checks** (always executed, version-conditional)
+- Cross-database iteration for extension, data type, and compatibility checks
+- Instance-wide `max_locks_per_transaction` calculation with a 20% safety buffer
+
+## Related AWS resources
+
+- [PostgreSQL on Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html)
+- [Upgrading the PostgreSQL DB engine for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html)
+- [Upgrades for Amazon Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_UpgradeDBInstance.PostgreSQL.html)
+- [Blue/Green Deployments for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the repository
+[LICENSE](https://github.com/awslabs/rds-support-tools/blob/main/LICENSE).

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/pg-major-version-upgrade-precheck-plpgsql.sql
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/plpgsql/pg-major-version-upgrade-precheck-plpgsql.sql
@@ -101,7 +101,6 @@ DECLARE
     v_source_le_11      boolean;
     v_source_le_13      boolean;
     v_source_ge_17      boolean;
-    v_is_aurora         boolean;
 BEGIN
     -- Prevent runaway queries from holding catalog locks too long
     SET LOCAL statement_timeout = 600000;   -- 10 minutes
@@ -146,12 +145,6 @@ BEGIN
     -- Validate target_version is within supported range (11-18)
     IF p_target_version < 11 OR p_target_version > 18 THEN
         RAISE EXCEPTION 'ERROR: Target version must be between 11 and 18. Got: %', p_target_version;
-    END IF;
-
-    -- Aurora PostgreSQL does not yet support target version 18
-    v_is_aurora := (to_regproc('aurora_version') IS NOT NULL);
-    IF v_is_aurora AND p_target_version >= 18 THEN
-        RAISE EXCEPTION 'ERROR: Aurora PostgreSQL does not support target version 18 yet. Supported: 11-17.';
     END IF;
 
     -- Version sanity check
@@ -1983,10 +1976,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 47. check_old_cluster_for_valid_slots - invalid slots [global] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_source_ge_17 THEN
+    IF v_source_ge_17 THEN
         SELECT count(*) INTO v_count
         FROM pg_catalog.pg_replication_slots
         WHERE slot_type = 'logical'
@@ -2023,10 +2013,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_source_ge_17 THEN
+    IF v_source_ge_17 THEN
         SELECT count(*) INTO v_count
         FROM pg_catalog.pg_replication_slots
         WHERE slot_type = 'logical'
@@ -2067,10 +2054,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 47c. check_old_cluster_for_valid_slots - active slots with WAL lag [global] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_source_ge_17 THEN
+    IF v_source_ge_17 THEN
         SELECT count(*) INTO v_count
         FROM pg_catalog.pg_replication_slots
         WHERE slot_type = 'logical'
@@ -2112,10 +2096,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 48. check_old_cluster_subscription_state [per-database] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_source_ge_17 THEN
+    IF v_source_ge_17 THEN
         SELECT count(*) INTO v_count
         FROM (
             -- Subscriptions missing replication origin
@@ -2169,21 +2150,18 @@ BEGIN
     -- --------------------------------------------
     -- Check 49. check_for_isn_and_int8_passing_mismatch [per-database]
     -- (All versions; contrib/isn relies on int8 pass-by-value behavior.
-    --  On RDS the old/new clusters normally have the same setting,
+    --  On RDS/Aurora the old/new clusters normally have the same setting,
     --  but we flag if contrib/isn is installed as informational.)
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 49. check_for_isn_and_int8_passing_mismatch [per-database] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSE
+
     SELECT count(*) INTO v_count
     FROM pg_catalog.pg_proc p
     WHERE p.probin = '$libdir/isn';
     IF v_count > 0 THEN
         v_status := '⚠️ WARNING';
-        v_msg := v_count || ' contrib/isn function(s) found. If old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. On RDS this is normally consistent, but verify before upgrading.';
+        v_msg := v_count || ' contrib/isn function(s) found. If old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. On RDS/Aurora this is normally consistent, but verify before upgrading.';
         SELECT string_agg(n.nspname || '.' || p.proname, E'\n    ' ORDER BY n.nspname, p.proname)
         INTO v_detail
         FROM pg_catalog.pg_proc p
@@ -2193,7 +2171,7 @@ BEGIN
         v_status := '✓ PASSED';
         v_msg := 'No contrib/isn functions found.';
     END IF;
-    END IF;
+
     RAISE NOTICE '%: %', v_status, v_msg;
     IF v_detail IS NOT NULL AND v_detail != '' THEN
         RAISE NOTICE '  Detail:'; RAISE NOTICE '    %', v_detail;
@@ -2209,10 +2187,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 50. check_for_not_null_inheritance [per-database] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_target_ge_18 THEN
+    IF v_target_ge_18 THEN
         SELECT count(*) INTO v_count
         FROM pg_catalog.pg_inherits i
         JOIN pg_catalog.pg_attribute ac ON ac.attrelid = i.inhrelid
@@ -2258,10 +2233,7 @@ BEGIN
     -- --------------------------------------------
     v_detail := '';
     RAISE NOTICE '=== 51. check_for_unicode_update [per-database] ===';
-    IF v_is_aurora THEN
-        v_status := '- SKIP';
-        v_msg := 'Skipped (Aurora PostgreSQL - not applicable).';
-    ELSIF v_source_ge_17 AND v_target_ge_18 THEN
+    IF v_source_ge_17 AND v_target_ge_18 THEN
         SELECT count(*) INTO v_count
         FROM (
             SELECT ix.indexrelid AS reloid

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/pg-major-version-upgrade-precheck.sh
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/shell/pg-major-version-upgrade-precheck.sh
@@ -4906,13 +4906,6 @@ EOF
         # Detect PostgreSQL major version for version-specific checks
         get_pg_major_version
         
-        # Detect if this is Aurora PostgreSQL (for skipping checks 47-51)
-        IS_AURORA=$(PGPASSWORD="${DB_PASS}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -t -A -c "SELECT (to_regproc('aurora_version') IS NOT NULL)::text;" 2>/dev/null)
-        IS_AURORA=${IS_AURORA:-false}
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Detected: Aurora PostgreSQL (Checks 47-51 will be skipped)"
-        fi
-        
         # Check 1: PostgreSQL Version
         execute_check \
             "PostgreSQL Version Check" \
@@ -6364,9 +6357,7 @@ Details: ${upgrade_targets}"
         fi
         
         # Check 47: Invalid Logical Replication Slots - Only for PG >= 17
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 47 (Invalid Logical Replication Slots) - Not applicable for Aurora PostgreSQL"
-        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+        if [ "$PG_MAJOR_VERSION" -ge 17 ]; then
             execute_check_all_dbs \
                 "Invalid Logical Replication Slots Check - what to check: \"Your installation contains invalidated logical replication slots. These slots cannot be migrated during pg_upgrade. Drop them before upgrading.\"" \
                 "Check for logical replication slots with invalidation_reason IS NOT NULL (PostgreSQL >= 17 slot migration)" \
@@ -6388,9 +6379,7 @@ Details: ${upgrade_targets}"
         fi
         
         # Check 47b: Inactive Logical Slots with Unconsumed WAL - Only for PG >= 17
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 47b (Inactive Logical Slots with Unconsumed WAL) - Not applicable for Aurora PostgreSQL"
-        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+        if [ "$PG_MAJOR_VERSION" -ge 17 ]; then
             execute_check_all_dbs \
                 "Inactive Logical Slots with Unconsumed WAL Check - what to check: \"Your installation contains inactive logical replication slots with unconsumed WAL. After shutdown, pg_upgrade will reject these. Either consume pending WAL or drop the slot(s).\"" \
                 "Check for inactive logical slots that have not consumed all WAL (PostgreSQL >= 17 slot migration)" \
@@ -6416,9 +6405,7 @@ Details: ${upgrade_targets}"
         fi
         
         # Check 47c: Active Logical Slots with WAL Lag - Only for PG >= 17 (WARNING only)
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 47c (Active Logical Slots with WAL Lag) - Not applicable for Aurora PostgreSQL"
-        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+        if [ "$PG_MAJOR_VERSION" -ge 17 ]; then
             execute_check_all_dbs \
                 "Active Logical Slots with WAL Lag Check" \
                 "Check for active logical slots with WAL lag - ensure consumers are caught up before stopping for upgrade (PostgreSQL >= 17)" \
@@ -6444,9 +6431,7 @@ Details: ${upgrade_targets}"
         fi
         
         # Check 48: Subscription State Check - Only for PG >= 17
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 48 (Subscription State Check) - Not applicable for Aurora PostgreSQL"
-        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+        if [ "$PG_MAJOR_VERSION" -ge 17 ]; then
             execute_check_all_dbs \
                 "Subscription State Check - what to check: \"Your installation contains subscriptions without replication origin or having relations not in i (initialize) or r (ready) state. Fix before upgrading.\"" \
                 "Check subscription replication origins and relation states for pg_upgrade compatibility (PostgreSQL >= 17)" \
@@ -6469,9 +6454,6 @@ Details: ${upgrade_targets}"
         fi
         
         # Check 49: contrib/isn and int8 Passing Mismatch (all versions, WARNING)
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 49 (contrib/isn Extension) - Not applicable for Aurora PostgreSQL"
-        else
         execute_check_all_dbs \
             "contrib/isn Extension Check" \
             "Check for contrib/isn functions - if old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. On RDS this is normally consistent." \
@@ -6485,12 +6467,8 @@ Details: ${upgrade_targets}"
             ORDER BY n.nspname, p.proname;" \
             "${output_file}" \
             "49"
-        fi
-        
+
         # Check 50: NOT NULL Inheritance Mismatch (all versions)
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 50 (NOT NULL Inheritance Mismatch) - Not applicable for Aurora PostgreSQL"
-        else
         execute_check_all_dbs \
             "NOT NULL Inheritance Mismatch Check - what to check: \"Your installation contains child tables that omit NOT NULL constraints present in their parent tables. This will cause pg_upgrade to fail when upgrading to PostgreSQL 18+. Fix with: ALTER TABLE child ALTER COLUMN col SET NOT NULL.\"" \
             "Check for child tables missing NOT NULL constraints that parent tables have" \
@@ -6513,12 +6491,9 @@ Details: ${upgrade_targets}"
             ORDER BY nc.nspname, cc.relname, ac.attname;" \
             "${output_file}" \
             "50"
-        fi
         
         # Check 51: Unicode-Dependent Objects - Only for PG >= 17 (WARNING only)
-        if [ "$IS_AURORA" = "true" ]; then
-            echo "Skipping Check 51 (Unicode-Dependent Objects) - Not applicable for Aurora PostgreSQL"
-        elif [ "$PG_MAJOR_VERSION" -ge 17 ]; then
+        if [ "$PG_MAJOR_VERSION" -ge 17 ]; then
             execute_check_all_dbs \
                 "Unicode-Dependent Objects Check" \
                 "Check for indexes/partitions/constraints using Unicode-dependent functions (lower, upper, initcap, regexp_*). If Unicode version differs between old and new clusters, consider REINDEX after upgrade." \

--- a/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/pg-major-version-upgrade-precheck-sql.sql
+++ b/postgres/diag/pg-major-version-upgrade-precheck-tool/sql/pg-major-version-upgrade-precheck-sql.sql
@@ -122,8 +122,7 @@ SELECT
   (current_setting('server_version_num')::int / 10000 <= 15
      AND :target_version >= 16)::text                                             AS need_aclitem_check,
   (current_setting('server_version_num')::int / 10000 <= 11)::text               AS source_le_11,
-  (current_setting('server_version_num')::int / 10000 <= 13)::text               AS source_le_13,
-  (to_regproc('aurora_version') IS NOT NULL)::text                               AS is_aurora
+  (current_setting('server_version_num')::int / 10000 <= 13)::text               AS source_le_13
 \gset
 
 -- Version sanity check
@@ -138,16 +137,6 @@ SELECT
 SELECT (:target_version < 11 OR :target_version > 18)::text AS version_out_of_range \gset
 \if :version_out_of_range
     \echo '❌ FAILED: target_version must be between 11 and 18.'
-    \quit
-\endif
-
--- ============================================
--- Aurora PostgreSQL does not yet support target version 18
--- ============================================
-SELECT (to_regproc('aurora_version') IS NOT NULL AND :target_version >= 18)::text AS aurora_target_invalid \gset
-\if :aurora_target_invalid
-    \echo '❌ FAILED: Aurora PostgreSQL does not support target version 18 yet.'
-    \echo '   Supported target versions for Aurora PostgreSQL: 11-17'
     \quit
 \endif
 
@@ -1840,13 +1829,9 @@ FROM (
 -- --------------------------------------------
 -- Check 47. check_old_cluster_for_valid_slots - invalid slots [global]
 -- (source >= 17; logical slot migration requires valid slots)
--- (Skipped for Aurora PostgreSQL - Aurora handles slot migration internally)
 -- --------------------------------------------
 \echo '=== 47. check_old_cluster_for_valid_slots - invalid slots [global] ==='
-\if :is_aurora
-    SELECT 'false' AS c47_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\elif :source_ge_17
+\if :source_ge_17
     SELECT (count(*) > 0)::text AS c47_failed,
            CASE WHEN count(*) > 0
                 THEN '❌ FAILED: ' || count(*) || ' invalidated logical slot(s). Drop them before upgrade.'
@@ -1878,10 +1863,7 @@ FROM (
 -- (source >= 17; inactive slots must have consumed all WAL before shutdown)
 -- --------------------------------------------
 \echo '=== 47b. check_old_cluster_for_valid_slots - unconsumed WAL [global] ==='
-\if :is_aurora
-    SELECT 'false' AS c47b_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\elif :source_ge_17
+\if :source_ge_17
     SELECT (count(*) > 0)::text AS c47b_failed,
            CASE WHEN count(*) > 0
                 THEN '❌ FAILED: ' || count(*) || ' inactive logical slot(s) with unconsumed WAL. '
@@ -1922,10 +1904,7 @@ FROM (
 -- (source >= 17; WARNING only - active slots with WAL lag may fail
 -- --------------------------------------------
 \echo '=== 47c. check_old_cluster_for_valid_slots - active slots with WAL lag [global] ==='
-\if :is_aurora
-    SELECT 'false' AS c47c_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\elif :source_ge_17
+\if :source_ge_17
     SELECT (count(*) > 0)::text AS c47c_failed,
            CASE WHEN count(*) > 0
                 THEN '⚠️ WARNING: ' || count(*) || ' active logical slot(s) with WAL lag. '
@@ -1975,10 +1954,7 @@ FROM (
 --  and each subscription must have a replication origin)
 -- --------------------------------------------
 \echo '=== 48. check_old_cluster_subscription_state [per-database] ==='
-\if :is_aurora
-    SELECT 'false' AS c48_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\elif :source_ge_17
+\if :source_ge_17
     SELECT (count(*) > 0)::text AS c48_failed,
            CASE WHEN count(*) > 0
                 THEN '❌ FAILED: ' || count(*) || ' subscription issue(s) found. Fix before upgrade.'
@@ -2034,15 +2010,11 @@ FROM (
 -- Check 49. check_for_isn_and_int8_passing_mismatch [per-database]
 -- --------------------------------------------
 \echo '=== 49. check_for_isn_and_int8_passing_mismatch [per-database] ==='
-\if :is_aurora
-    SELECT 'false' AS c49_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\else
 SELECT (count(*) > 0)::text AS c49_failed,
        CASE WHEN count(*) > 0
             THEN '⚠️ WARNING: ' || count(*) || ' contrib/isn function(s) found. ' ||
                  'If old/new clusters disagree on float8_pass_by_value, pg_upgrade will fail. ' ||
-                 'On RDS this is normally consistent, but verify before upgrading.'
+                 'On RDS/Aurora this is normally consistent, but verify before upgrading.'
             ELSE '✓ PASSED'
        END AS c49_status
 FROM pg_catalog.pg_proc p
@@ -2057,7 +2029,6 @@ WHERE p.probin = '$libdir/isn' \gset
     WHERE p.probin = '$libdir/isn'
     ORDER BY n.nspname, p.proname;
 \endif
-\endif
 
 \echo ''
 
@@ -2067,10 +2038,7 @@ WHERE p.probin = '$libdir/isn' \gset
 -- Child tables must not omit NOT NULL constraints that parents have.
 -- --------------------------------------------
 \echo '=== 50. check_for_not_null_inheritance [per-database] ==='
-\if :is_aurora
-    SELECT 'false' AS c50_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\elif :target_ge_18
+\if :target_ge_18
     SELECT (count(*) > 0)::text AS c50_failed,
            CASE WHEN count(*) > 0
                 THEN '❌ FAILED: ' || count(*) || ' child column(s) missing NOT NULL inherited from parent. ' ||
@@ -2118,10 +2086,6 @@ WHERE p.probin = '$libdir/isn' \gset
 -- if the Unicode version changed between old and new clusters.
 -- --------------------------------------------
 \echo '=== 51. check_for_unicode_update [per-database] ==='
-\if :is_aurora
-    SELECT 'false' AS c51_failed \gset
-    \echo '- Skipped (Aurora PostgreSQL - not applicable)'
-\else
 SELECT (:source_ge_17 = 'true' AND :target_ge_18 = 'true')::text AS need_c51 \gset
 \if :need_c51
     WITH
@@ -2235,7 +2199,6 @@ SELECT (:source_ge_17 = 'true' AND :target_ge_18 = 'true')::text AS need_c51 \gs
 \else
     SELECT 'false' AS c51_failed, '- SKIP' AS c51_status \gset
     \echo '- Skipped (only meaningful when source >= 17 and target >= 18)'
-\endif
 \endif
 
 \echo ''


### PR DESCRIPTION
Adjusted the major version upgrade precheck to support upgrading Aurora PostgreSQL to major version 18.

*Description of changes:*

Aurora PostgreSQL now supports major version 18. Previously the precheck
tool blocked Aurora from target version 18 and skipped checks 47–51 for
Aurora clusters. This change removes those Aurora-specific exclusions so
Aurora is validated the same way as RDS for PostgreSQL when upgrading to 18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
